### PR TITLE
Fixing a blogpost URL in Domain Names page

### DIFF
--- a/content/doc/administrate/domain-names.md
+++ b/content/doc/administrate/domain-names.md
@@ -196,4 +196,4 @@ example.com/api    ->     my-static-site/index.php
 
 ## Gandi CNAME configuration
 
-Here is [an article that demonstrates a simple setup for Gandi CNAMEs](https://blog.clever-cloud.com/blog/features/2019/03/05/gandi-domain-on-clever-cloud).
+Here is [an article that demonstrates a simple setup for Gandi CNAMEs](https://www.clever-cloud.com/blog/features/2019/03/05/gandi-domain-on-clever-cloud/).


### PR DESCRIPTION
This change lead to valid page of the following blog post: https://www.clever-cloud.com/blog/features/2019/03/05/gandi-domain-on-clever-cloud/.

Fixes the issue https://github.com/CleverCloud/documentation/issues/90 