### PR TITLE
fix(warp10): use c2 cluster instead of c1

### DIFF
--- a/content/doc/metrics/warp10.md
+++ b/content/doc/metrics/warp10.md
@@ -4,6 +4,8 @@ title: Warp 10
 shortdesc: Warp 10. Geo Time series database. Presentations, concepts and examples
 tags:
   - metrics
+aliases:
+- /doc/administrate/metrics/warp10/
 keywords:
   - GTS
   - warp 10

--- a/content/doc/metrics/warp10.md
+++ b/content/doc/metrics/warp10.md
@@ -70,7 +70,7 @@ Builtin function :
 The Clever Cloud Warp 10 endpoint is:
 
 ```
-https://c1-warp10-clevercloud-customers.services.clever-cloud.com/api/v0
+https://c2-warp10-clevercloud-customers.services.clever-cloud.com/api/v0
 ```
 
 You can find documentation about endpoint gateway [here](https://www.warp10.io/content/03_Documentation/03_Interacting_with_Warp_10/01_Introduction).
@@ -80,7 +80,7 @@ You can find documentation about endpoint gateway [here](https://www.warp10.io/c
 You can query our Warp 10 platform with your own script. Here's a curl example :
 
 ```bash
-  curl -T <Path/to/a/warpscript_file> https://c1-warp10-clevercloud-customers.services.clever-cloud.com/api/v0/exec
+  curl -T <Path/to/a/warpscript_file> https://c2-warp10-clevercloud-customers.services.clever-cloud.com/api/v0/exec
 ```
 
 > Do not forget the endpoint. `exec` in the previous exemple.


### PR DESCRIPTION
## Checklist

- [ ] My PR is related to an opened issue : #

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Documentation content changes
- [ ] Bugfix on the site
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

Warp10 documentation told customers to use a Warp10 cluster which isn't alive anymore, `c1` into `c2` :partying_face: 

### Why is this needed?


## Reviewes
_Who should review these changes?_ @

