### PR TITLE
update CC_RUN_COMMAND + fix default callout in dark mode

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -29,10 +29,12 @@
   background-color: #f5f5f5;
 }
 
-/* Colors for dark theme */
+/* Colors for dark theme */ 
 .dark {
   --primary-hue: -165deg;
+ /* --primary-saturation: 100%; */
 }
+
 
 /* Fonts */
 h1, .content h1,

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -29,10 +29,9 @@
   background-color: #f5f5f5;
 }
 
-/* Colors for dark theme */ 
+/* Colors for dark theme */
 .dark {
   --primary-hue: -165deg;
- /* --primary-saturation: 100%; */
 }
 
 

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -66,6 +66,10 @@ So you can alter the build&start process for your application.
 |`CC_TASK` | If set as true, the deployer runs `CC_RUN_COMMAND` and close the instance after havind run the task. Trigger an execution using `git push` or starting your instance  | false |
 |[`CC_TROUBLESHOOT`](/doc/find-help/troubleshooting "Troubleshooting") | Enable debug log level, will also keep the VM up after failure for 15 minutes so you can SSH and debug. Don't forget to cancel deployment if you push a new commit. | false |
 
+{{< callout emoji="🐳" >}}
+  `CC_RUN_COMMAND` has no effect on Docker. To run Docker, use `CMD` in your [Dockerfile](/doc/applications/docker/#dockerized-rust-application-deployment).
+{{< /callout >}}
+
 
 #### Deployment hooks
 

--- a/layouts/shortcodes/callout.html
+++ b/layouts/shortcodes/callout.html
@@ -6,7 +6,7 @@
   {{ $emoji = index $calloutEmojiDict $type }}
 {{ end }}
 
-{{ $defaultClass := " callout bg-gray-100 text-gray-800 dark:border-gray-400/30 dark:bg-gray-400/20 dark:text-gray-800" }}
+{{ $defaultClass := " callout bg-gray-100 text-gray-800 dark:border-blue-200/30 dark:bg-neutral-800 dark:text-blue-200" }}
 {{ $infoClass := "callout border-blue-200 bg-blue-100 text-blue-900 dark:border-blue-200/30 dark:bg-blue-900/30 dark:text-blue-200" }}
 {{ $warningClass := "callout border-yellow-100 bg-yellow-50 text-yellow-900 dark:border-yellow-200/30 dark:bg-yellow-700/30 dark:text-yellow-200" }}
 {{ $errorClass := "callout border-red-200 bg-red-100 text-red-900 dark:border-red-200/30 dark:bg-red-900/30 dark:text-red-200" }}


### PR DESCRIPTION
## Checklist

- [x] My PR is related to an opened issue : #9 

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Documentation content changes
- [x] Bugfix on the site: fix default callout on dark mode
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

_A summary of the changes_

A note about `CC_RUN_COMMAND` with no effect on Docker instances has been added (ran myself into this issue a few days ago), as a default callout.

Took the opportunity to fix dark mode for default callouts. 

Both changes can be compared here: 

- this branch: http://clever-doc-review-cc-run-docker.cleverapps.io/doc/reference/reference-environment-variables/#control-the-deployments-behavior
- main branch: https://developers.clever-cloud.com/doc/reference/reference-environment-variables/#control-the-deployments-behavior

### Why is this needed?

It's needed because otherwise, users will try to add `CC_RUN_COMMAND` to a Docker instance to fix deployment issues, but this won't have any effect and not debugging anything. It saves time for our users and discourages them to try this method and encourages them to use `CMD` in their Dockerfile instead.

## Reviewes
_Who should review these changes?_ @Bencaddyro 

