### PR TITLE
fix: Go build/deploy page revamp

### DIFF
--- a/content/doc/applications/golang/_index.md
+++ b/content/doc/applications/golang/_index.md
@@ -19,11 +19,7 @@ aliases:
 
 ## Overview
 
-Clever Cloud allows you to deploy any Go application. This page will explain you how to set up your application to run it on our service.
-
-We currently support single module applications only. That means that your sources files just need to be at the project's root, and you can't have multiple modules running.
-
-You do not need to change a lot in your application, the *requirements* will help you configure your applications with some mandatory files to add, and properties to setup.
+Clever Cloud allows you to deploy any Go application. This page will explain you how to set up your project to run it on our service. You won't not need to change a lot, the *requirements* will help you configure your applications with some mandatory files to add, and properties to setup.
 
 {{< readfile file="create-application.md" >}}
 

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -161,11 +161,11 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 
 [Go Documentation](/doc/applications/golang)
 
-|  Name  |  Description  |  Default value  |
-|-----------------------|------------------------------|--------------------------------|
-|`CC_GO_BUILD_TOOL` |Available values: `gomod`, `gobuild`, `goget`. Makes the deployer use `go modules`, `go get` or `go build` to build your application. | `goget` |
-|`CC_GO_PKG` | Makes the deployer run go get `${CC_GO_PKG}` instead of go get `<app_id>`.  |  |
-|`CC_GO_RUNDIR` | Makes the deployer use the specified directory to run your binary. If your application must be in `$GOPATH/src/company/project` for your vendored dependencies, set this variable to `company/project` |  |
+| Name | Descrption |
+| :------- | :---- |
+| `CC_GO_BUILD_TOOL` | Available values: `gomod`, `gobuild`. Build and install your application. `goget` still exists but is deprecated. |
+| `CC_GO_RUNDIR` | Run the application from the specified path, relative to `$GOPATH/src/`, now deprecated. |
+| `CC_GO_PKG` | Tell the `CC_GO_BUILD_TOOL` which file contains the `main()` function, default `main.go`. |
 
 ## Haskell
 

--- a/static/partials/language-specific-deploy/go.md
+++ b/static/partials/language-specific-deploy/go.md
@@ -6,7 +6,10 @@ By default, we consider that your repository contains a single application. Be s
 * It listens on port `8080`
 * You follow our build/run instructions
 
-In most cases you won't need to change anything to your application, except host/port and some configuration variables.
+In most cases you won't need to change anything to your application, except host/port and some configuration variables. 
+
+### Complementary runtime
+If you need a runtime environment such as Node.js or tools to build a frontend for example, some are available in our Go instances. You can use them through scripts launched by [deployments hooks](/doc/develop/build-hooks/) and [Environment variables](/doc/reference/reference-environment-variables/) sometimes allow you to configure them. So if you need a specific version of Node.js, set `CC_NODE_VERSION` (it could be `node` (latest), `lts/*`, `20` or `21.5.0`).
 
 ### Modern Go project structure
 There are multiple ways to build/run a Go application, and this has evolved over the years. In its modern form a Go project can be a:

--- a/static/partials/language-specific-deploy/go.md
+++ b/static/partials/language-specific-deploy/go.md
@@ -19,24 +19,29 @@ A module can be installed locally or from a remote repository if you pass its UR
 If you want to limit from where a package can be imported it [should placed](https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit) in a folder named `ìnternal/`. Access to functions in `.go` files is defined depending [on their name](https://go.dev/tour/basics/3): if it starts with a capital letter it's a public functions, if not it's a private function.
 
 For a complete project, a common files/folders organization can be:
-```
-application-root/
-├── go.work
-├── Makefile
-├── cmd/
-│   ├── main.go
-│   ├── other-file.go
-│   ├── other-package.go
-|   └── ...
-└── module/
-        ├── go.mod
-        ├── go.sum
-        ├── main.go
-        ├── other-module-file.go
-        └──internal/
-            └── internal-package/
-                └── internal-package-file.go
-```
+{{< filetree/container >}}
+  {{< filetree/folder name="application-root/" >}}
+    {{< filetree/file name="go.work" >}}
+    {{< filetree/file name="Makefile" >}}
+    {{< filetree/folder name="cmd/" >}}
+      {{< filetree/file name="main.go" >}}
+      {{< filetree/file name="other-file.go" >}}
+      {{< filetree/file name="other-package.go" >}}
+      {{< filetree/file name="…" >}}
+    {{< /filetree/folder >}}
+        {{< filetree/folder name="module/" >}}
+          {{< filetree/file name="go.mod" >}}
+          {{< filetree/file name="go.sum" >}}
+          {{< filetree/file name="main.go" >}}
+          {{< filetree/file name="other-module-file.go" >}}
+            {{< filetree/folder name="internal/" >}}
+              {{< filetree/folder name="internal-package/" >}}
+                {{< filetree/file name="internal-package-file.go" >}}
+              {{< /filetree/folder >}}
+            {{< /filetree/folder >}}
+      {{< /filetree/folder >}}
+  {{< /filetree/folder >}}
+{{< /filetree/container >}}
 
 ### Go build and deploy on Clever Cloud
 In such a situation, our strategy is to let the user choose how to build/run its application and make the deployment easy anyway. At first, we used the `goget` method, which is now deprecated. Thus, you can now use `gobuild` (for packages), `gomod` (for modules) or a configuration file. The latter will allow you to define a `Makefile` for custom build and a `main` executable to start the application.
@@ -48,8 +53,7 @@ In such a situation, our strategy is to let the user choose how to build/run its
 #### Through Makefile and JSON configuration
 Create a file name `go.json` in a `clevercloud/` folder at the root of your repository. It will allow you to ask for a custom build through a `Makefile` ([learn more about it](https://en.wikipedia.org/wiki/Make_(software)#Makefiles)). For example with a single package in `main.go`:
 
-`/clevercloud/go.json`
-```json
+```json {filename="clevercloud/go.json"}
 {
   "deploy": {
     "makefile": "Makefile",
@@ -58,8 +62,7 @@ Create a file name `go.json` in a `clevercloud/` folder at the root of your repo
 }
 ```
 
-`/Makefile`
-```Makefile
+```Makefile {filename="Makefile"}
 BINARY=bin/myApp
 
 build:

--- a/static/partials/language-specific-deploy/go.md
+++ b/static/partials/language-specific-deploy/go.md
@@ -1,143 +1,92 @@
 ## Configure your Go application
 
-### Mandatory configuration
+### Mandatory needs
+By default, we consider that your repository contains a single application. Be sure that:
+* It listens to the wild network `0.0.0.0`, not only `localhost` or `127.0.0.1`
+* It listens on port `8080`
+* You follow our build/run instructions
 
-Be sure that:
+In most cases you won't need to change anything to your application, except host/port and some configuration variables.
 
-* Your application listens to the wild network **0.0.0.0**, not only `localhost` or `127.0.0.1`
-* Your application listens on port **8080**
-* You put your main code in a file named `main.go` (if you do not do that, Go will generate a library and not an executable)
+### Modern Go project structure
+There are multiple ways to build/run a Go application, and this has evolved over the years. In its modern form a Go project can be a:
+- `Package`: one or more `.go` files you can `build` or `run`. `main` package and `main()` function are the default entry point
+- `Module`: one or more packages you can `install`, defined in a `go.mod` file (`go.sum` for checksums)
+- `Workspace`: one or more modules seamlessly combined, defined in a `go.work` file
 
-Apart from listening on port 8080, there is nothing to change on your application.
+A module can be installed locally or from a remote repository if you pass its URL to the `install` command. A `Makefile` is sometimes used to define how a Go project is built, run and/or cleaned. The lightest form of a Go project is a `main.go` file to build. Some years ago, the `src/` folder was often used for source code, but using the `cmd/` folder instead is now a common practice. 
 
-### Go production build on Clever Cloud
+If you want to limit from where a package can be imported it [should placed](https://docs.google.com/document/d/1e8kOo3r51b2BWtTs_1uADIA5djfXhPT36s6eHVRIvaU/edit) in a folder named `ìnternal/`. Access to functions in `.go` files is defined depending [on their name](https://go.dev/tour/basics/3): if it starts with a capital letter it's a public functions, if not it's a private function.
 
-* We automatically build and run your application, see [Build the application](#build-the-application).
-* By default, we consider that your repository contains a single application. We put your application in `${GOPATH}/src/{app_id}` and then run `go get {app_id}`. Refer to [clevercloud/go.json settings](#clevercloud/go.json-settings) if you want to override this behaviour.
-* By default, we deploy your application as a Go project named "<app_id>". You can find the app_id of your application under the environment variable `APP_ID`. Please refer to [environment injection](#environment-injection) to know how to query it in your application.
-* The executable is run with the application's root as its current path. So if your application has a `static` folder at its root, it will be accessible via `./static` in your application.
+For a complete project, a common files/folders organization can be:
+```
+application-root/
+├── go.work
+├── Makefile
+├── cmd/
+│   ├── main.go
+│   ├── other-file.go
+│   ├── other-package.go
+|   └── ...
+└── module/
+        ├── go.mod
+        ├── go.sum
+        ├── main.go
+        ├── other-module-file.go
+        └──internal/
+            └── internal-package/
+                └── internal-package-file.go
+```
 
-## Build the application
+### Go build and deploy on Clever Cloud
+In such a situation, our strategy is to let the user choose how to build/run its application and make the deployment easy anyway. At first, we used the `goget` method, which is now deprecated. Thus, you can now use `gobuild` (for packages), `gomod` (for modules) or a configuration file. The latter will allow you to define a `Makefile` for custom build and a `main` executable to start the application.
 
-To build your application, you can use one of the three methods available:
+{{< callout type="info" >}}
+  If the required Go version declared in the `go.mod` is superior to the version built in the instance, it will be automatically updated.
+{{< /callout >}}
 
-* `go modules`
-* `go build`
-* `go get` (default)
+#### Through Makefile and JSON configuration
+Create a file name `go.json` in a `clevercloud/` folder at the root of your repository. It will allow you to ask for a custom build through a `Makefile` ([learn more about it](https://en.wikipedia.org/wiki/Make_(software)#Makefiles)). For example with a single package in `main.go`:
 
-### Go modules
-
-If your project is compatible with go modules, be sure that the `go.mod` file is in your git tree. Note that it **must** be at the root of your application (see the [`APP_FOLDER` environment variable if it isn't]({{< ref "doc/reference/reference-environment-variables.md" >}})
-
-For now, you have to add the environment variable `CC_GO_BUILD_TOOL=gomod` to build using the go modules. In a future release, we will automatically
-build with go modules if the `go.mod` file is present at the root of your git tree.
-
-Your project's entrypoint should be in the same folder as the `go.mod` file and be named `main.go`. If it isn't, you have to specify it using the following environment variable:
-
-`CC_GO_PKG=./path/to/entrypoint.go`
-
-### Go build
-
-If your project does not support `go modules`, it may include your vendored dependencies. In this case, `go build` must be used.
-
-To use `go build`, you have to set the `CC_GO_BUILD_TOOL=gobuild` environment variable.
-We will then deploy your project in a classic `GOPATH` hierarchy using `go build`.
-
-The `CC_GO_PKG` environment variable can be used to define the main file of your application. Defaults to `main.go`.
-
-### Go get
-
-* If your application has submodules and imports them with their full path *or* your main project is an external package hosted, for instance on GitHub (like `github.com/me/myproject`), you can [define the environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_GO_PKG=github.com/me/myproject`. We will now run `go get ${CC_GO_PKG}` instead of `go get <app_id>`.
-
-Also, go get requires that you put your main code in a file named `main.go`. If you
-do not do that, go will generate a library and not an executable. So if you get a `Nothing
-listening on port 8080`, please check that your main file is named `main.go`.
-
-You can also force the use of `go get` by setting the environment variable `CC_GO_BUILD_TOOL=goget`. This is currently the default.
-
-**Note**: if you get a `Nothing listening on port 8080` error, please check that your main file is named `main.go`.
-
-### Customize build using environment variables
-
-You can customize the build process of your Go application using the following environment variables:
-
-Variable | Usage
----------|------
-`CC_GO_PKG` | Makes the deployer run `go get ${CC_GO_PKG}` instead of `go get <app_id>` or `go install ${CC_GO_PKG}` instead of `go install mypackage`.
-`CC_GO_BUILD_TOOL` | Available values: `gomod`, `goget`, `gobuild`. Makes the deployer use `go modules`, `go get`, or `go build` to build your application. If not specified, defaults to `goget`.
-`CC_GO_RUNDIR` | Makes the deployer use the specified directory to run your binary. If your application must be in `$GOPATH/src/company/project` for your vendored dependencies, set this variable to `company/project`.
-
-### clevercloud/go.json
-
-This configuration file is optional.
-
-If you want to configure precisely your dependencies (e.g. have private libraries, or specific versions of some libraries), here is the way:
-
-1. Make your repository have a `GOPATH` structure:
-
-{{< filetree/container >}}
-  {{< filetree/folder name="./" >}}
-    {{< filetree/folder name="myapp" >}}
-    {{< /filetree/folder >}}
-    {{< filetree/folder name="foo" >}}
-        {{< filetree/folder name="module1" >}}
-        {{< /filetree/folder >}}
-        {{< filetree/folder name="module2" >}}
-        {{< /filetree/folder >}}
-    {{< /filetree/folder >}}
-    {{< filetree/folder name="module3" >}}
-    {{< /filetree/folder >}}
-  {{< /filetree/folder >}}
-{{< /filetree/container >}}
-
-Here you have the modules `myapp`, `foo/module1`, `foo/module2` and `module3`.
-
-2. Create a *clevercloud/go.json* file at the top of your repository:
-
-{{< filetree/container >}}
-  {{< filetree/folder name="./" >}}
-    {{< filetree/folder name="clevercloud" >}}
-      {{< filetree/file name="go.json" >}}
-    {{< /filetree/folder >}}
-    {{< filetree/folder name="src" >}}
-      {{< filetree/folder name="myapp" >}}
-      {{< /filetree/folder >}}
-    {{< /filetree/folder >}}
-  {{< /filetree/folder >}}
-{{< /filetree/container >}}
-
-3. In the go.json file, put the following:
-
-```json{linenos=table}
+`/clevercloud/go.json`
+```json
 {
-    "deploy": {
-        "appIsGoPath": true,
-        "main": "myapp"
-    }
+  "deploy": {
+    "makefile": "Makefile",
+    "main": "bin/myApp"
+  }
 }
 ```
 
-If `appIsGoPath` is present and equals `true`, then we consider that your repo root is the *GOPATH*.
+`/Makefile`
+```Makefile
+BINARY=bin/myApp
 
-The `main` field then becomes mandatory and must be the name of the module you want to run.
+build:
+#	To install a specific Go version, you can add:
+#	go install golang.org/dl/gox.xx.x@latest
+#	${HOME}/go_home/bin/gox.xx.x download
+#	Then use `${HOME}/go_home/bin/gox.xx.x` instead of `go`
+	echo "Build the application as ./${BINARY}"
+	go build -o ${BINARY} main.go
+```
 
-E.g. if you want to run `module1`, `main` must be `foo/module1`.
+You'll find a more complex project using a Go Workspace and a `Makefile` [here](https://github.com/CleverCloud/go-workspaces).
 
-4. (Optional) Add a "execDir" field to the "deploy" object:
+#### Through Environment variables
+If you don't want to add a file to your project, you can set one of these environment variables:
 
-    ```json{linenos=table}
-    {
-        "deploy": {
-            "appIsGoPath": true,
-            "main": "myapp",
-            "execDir": "src/myapp"
-        }
-    }
-    ```
+| Name | Description |
+| :------- | :---- |
+| `CC_GO_BUILD_TOOL` | Available values: `gomod`, `gobuild`. Build and install your application. `goget` still exists but is deprecated. |
+| `CC_GO_RUNDIR` | Run the application from the specified path, relative to `$GOPATH/src/`, now deprecated. |
+| `CC_GO_PKG` | Tell the `CC_GO_BUILD_TOOL` which file contains the `main()` function, default `main.go`. |
 
-The `execDir` value must be relative to the root of your repo.
+- **gobuild**
+To build a Go package, your project may include vendored dependencies (in the `vendor/` folder). `CC_GO_PKG` can be set to define the main file of your application (default `main.go`).
 
-In the example above, we will run the application in the src/myapp directory.
+- **gomod**
+To build a Go module, be sure that the `go.mod` file is in your git tree and at the root of your application. Your project's entrypoint should be in the same folder as the `go.mod` file and be named `main.go`. If it isn't, you have to set `CC_GO_PKG=path/to/entrypoint.go`.
 
 {{< readfile file="env-injection.md" >}}
 

--- a/static/partials/language-specific-deploy/go.md
+++ b/static/partials/language-specific-deploy/go.md
@@ -9,7 +9,7 @@ By default, we consider that your repository contains a single application. Be s
 In most cases you won't need to change anything to your application, except host/port and some configuration variables. 
 
 ### Complementary runtime
-If you need a runtime environment such as Node.js or tools to build a frontend for example, some are available in our Go instances. You can use them through scripts launched by [deployments hooks](/doc/develop/build-hooks/) and [Environment variables](/doc/reference/reference-environment-variables/) sometimes allow you to configure them. So if you need a specific version of Node.js, set `CC_NODE_VERSION` (it could be `node` (latest), `lts/*`, `20` or `21.5.0`).
+If you need a runtime environment such as [Node.js](/doc/applications/javascript/nodejs/) or tools to build a frontend for example, some are available in our Go instances. You can use them through scripts launched by [deployments hooks](/doc/develop/build-hooks/) and [Environment variables](/doc/reference/reference-environment-variables/) sometimes allow you to configure them. So if you need a specific version of Node.js, set `CC_NODE_VERSION` (it could be `node` (latest), `lts/*`, `20` or `21.5.0`).
 
 ### Modern Go project structure
 There are multiple ways to build/run a Go application, and this has evolved over the years. In its modern form a Go project can be a:
@@ -94,6 +94,11 @@ To build a Go package, your project may include vendored dependencies (in the `v
 - **gomod**
 To build a Go module, be sure that the `go.mod` file is in your git tree and at the root of your application. Your project's entrypoint should be in the same folder as the `go.mod` file and be named `main.go`. If it isn't, you have to set `CC_GO_PKG=path/to/entrypoint.go`.
 
+The final command will be: 
+
+```
+go install $CC_GO_PKG
+```
 {{< readfile file="env-injection.md" >}}
 
 To access environment variables from your code, just get them from the environment with `PATH`: `os.Getenv("MY_VARIABLE")`.


### PR DESCRIPTION
Same table/headers in env var reference and Go page, but not as a partial, as it will certainly not be necessary anymore in a coming update

## Checklist

- [x] My PR is related to an opened issue : fix #80

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Documentation content changes
- [ ] Bugfix on the site
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- Are there other PRs related to this one? -->

A revamp of the Go deploy documentation, preparing for next steps on this runtime

## Reviewes
_Who should review these changes?_ @

