### PR TITLE
fix: add white background to Heptapod SVG

### DIFF
--- a/static/images/doc/clever-cloud-runners-basic-with-runtimes-alt.svg
+++ b/static/images/doc/clever-cloud-runners-basic-with-runtimes-alt.svg
@@ -8,6 +8,7 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   style="background-color: white;"
    width="1674"
    height="520"
    viewBox="0 0 442.91251 137.58333"


### PR DESCRIPTION
## Checklist

- [ ] My PR is related to an opened issue : #

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Documentation content changes
- [ ] Bugfix on the site
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description
The background of the Heptapod SVG was transparent, so it wasn't looking good on dark theme