### PR TITLE
fix(changelog): adjust the icon alignment inside level 3 headings

### DIFF
--- a/layouts/changelog/list.html
+++ b/layouts/changelog/list.html
@@ -16,7 +16,7 @@
         {{ $paginator := .Paginate (where .Data.Pages "Type" "changelog") }}
         {{ range $paginator.Pages.GroupByDate "January, 2006" }}
         <h3 style="text-decoration: none;"
-        class="block font-semibold mt-8 text-2xl text-gray-500 dark:text-gray-300">
+        class="block font-semibold flex items-center gap-1 mt-8 text-2xl text-gray-500 dark:text-gray-300">
           <span
           class="inline-block align-text-bottom icon">
             {{- partial "utils/icon.html" (dict "name" "clock" "attributes" "height=24") -}}
@@ -81,3 +81,4 @@
     <div class="max-xl:hidden h-0 w-64 shrink-0"></div>
   </div>
 {{ end }}
+


### PR DESCRIPTION
## Checklist

- [ ] My PR is related to an opened issue : #

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] Documentation content changes
- [x] Bugfix on the site
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description

This PR centers the icon vertically within the heading used for every changelog entry.

Currently it looks like this:
![image](https://github.com/CleverCloud/documentation/assets/100240294/80c9650d-687f-4f64-9705-5539ad9cffc9)
With this PR, it would look like this:
![image](https://github.com/CleverCloud/documentation/assets/100240294/066f3346-483d-416a-8cac-49f4c2393b9f)

I've only added a few classes to center the icon vertically and add some gap so this should be easy to review if you want to merge it.

### Why is this needed?

This PR may be closed if you think the current icon alignment is fine.
Maybe it's not needed, depends on the alignment you prefer :smile: 

## Reviewes
_Who should review these changes?_ @juliamrch 

