### PR TITLE
fix(cli) fix Github option to lowercase

### DIFF
--- a/content/doc/CLI/create.md
+++ b/content/doc/CLI/create.md
@@ -72,7 +72,7 @@ When creating your application, you can link it to GitHub for deployments.
 
 ```shell
 # Link an application to GitHub
-clever create --GitHub <owner>/<repository>
+clever create --github <owner>/<repository>
 ```
 
 ## Addon creation process


### PR DESCRIPTION
## Checklist

- [ ] My PR is related to an opened issue : #

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] Documentation content changes
- [x] Bugfix on the site
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description
I found an error in the documentation of the CLI.

`clever create --type php myApp --GitHub owner/myRepo`  
Return: `Unknown option: GitHub`

### Why is this needed?
Change `GitHub` to lowercase `github` because the CLI seems to have case sensitive system.

## Reviewes
@juliamrch 

