### PR TITLE
Add sitemap in robots.txt

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: 
+baseURL: https://developers.clever-cloud.com
 languageCode: en-us
 title: Clever Cloud Documentation
 paginate: 50 #Number of item to show in the changelog section before pagination

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: {{ site.Home.Sitemap.Filename | absURL }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,28 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- if not (or 
+      (hasPrefix .RelPermalink "/tags") 
+      (hasPrefix .RelPermalink "/categories") 
+      (hasPrefix .RelPermalink "/readme")) 
+    -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.LanguageCode }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.LanguageCode }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>


### PR DESCRIPTION
## Checklist

- [ ] My PR is related to an opened issue : #

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [ ] Documentation content changes
- [ ] Bugfix on the site
- [ ] Build related changes
- [x] Other (please describe):
      
## Description
Sitemap was generated but not mentioned in `robots.txt`. I added it through a template.

I've set the `baseURL` parameter as [it's needed](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap?hl=en#sitemap-best-practices) to generate full URL for such content.

I also modified [default `sitemap.xml` template](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/sitemap.xml) from Hugo to remove some bad links, which are not content we want to link from search engines in sitemap: empty tags/categories or readme pages.


