### PR TITLE
fix: play 1 & 2 guide links

### DIFF
--- a/content/doc/applications/java/_index.md
+++ b/content/doc/applications/java/_index.md
@@ -27,8 +27,8 @@ Find detailed instructions according to your framework
   {{< card link="/doc/applications/java/java-jar" title="Jar" icon="java" >}}
   {{< card link="/doc/applications/java/java-maven" title="Maven" icon= "maven">}}
   {{< card link="/doc/applications/java/java-war" title="War/Ear" icon="java" >}}
-  {{< card link="/doc/applications/java/play-framework-1" title="Play 1" icon="play" >}}
-  {{< card link="/doc/applications/java/play-framework-2" title="Play 2" icon="play" >}}
+  {{< card link="/guides/play-framework-1" title="Play 1" icon="play" >}}
+  {{< card link="/guides/play-framework-2" title="Play 2" icon="play" >}}
   
 {{< /cards >}}
 


### PR DESCRIPTION
## Checklist

- [X] My PR is related to an opened issue : #192

**⚠️ If changes affect GitHub Action files**

- [ ] I have added tests to cover my changes : [link](url)

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [X] Documentation content changes
- [ ] Bugfix on the site
- [ ] Build related changes
- [ ] Other (please describe):
      
## Description

This PR attempt to fix broken play1 and 2 links by redirecting to related guide pages.


### Why is this needed?


## Reviewes



