### PR TITLE
correct docker command

### DIFF
--- a/content/doc/CLI/getting_started.md
+++ b/content/doc/CLI/getting_started.md
@@ -183,7 +183,7 @@ If you are using docker, you can use the image provided [here](https://hub.docke
 
 ```sh
 docker pull clevercloud/clever-tools
-docker run --rm clever-tools <command>
+docker run --rm clevercloud/clever-tools <command>
 ```
 
 #### Dockerfile


### PR DESCRIPTION
correct docker command with full image name

## Describe your PR

full docker name of the `docker run` command, ie `clevercloud/clever-tools` (vendor/image-name)  
running the command with just the image name will not work


## Checklist

- [ ] My PR is related to an opened issue : #
- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)


## Reviewes
_Who should review these changes?_ @

