### PR TITLE
indicate correct format of private key in  TLS certificates to add

### DIFF
--- a/content/doc/administrate/ssl.md
+++ b/content/doc/administrate/ssl.md
@@ -84,13 +84,16 @@ You need to paste a PEM bundle containing (in this order):
 You should create a `file.pem` containing:
 
 ```text {filename="file.pem"}
------BEGIN RSA PRIVATE KEY-----
+-----BEGIN PRIVATE KEY-----
 <the private key>
------END RSA PRIVATE KEY-----
+-----END PRIVATE KEY-----
 -----BEGIN CERTIFICATE-----
 <the certificate>
 -----END CERTIFICATE-----
 ```
+
+Remove any possible mention of the algorithm in the footer and header.
+For instance, the API does not parse `-----BEGIN RSA PRIVATE KEY-----`, remove the `RSA` part.
 
 You can add optionnal intermediate certificates by appending them to the file as
 


### PR DESCRIPTION
We have found the documentation to be incorrect about TLS certificates to add.
When adding a pem-formatted certificate, if the algorithm is mentionned in the header or footer of a private key, the certificate will not be parsed by [our API ](https://api.clever-cloud.com/v2/certificates/new).

My PR is NOT related to an opened issue but it matches the change made on the API.

- [x] I've read the [contributing guidelines](../CONTRIBUTING.md)


## Reviewes
Please @juliamrch, @cnivolle
And @KannarFr too (this is a follow-up on the change on the certificate-adding API).

