### PR TITLE
elixir: version bump to 1.15 & 1.16

### DIFF
--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -149,7 +149,7 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 
  |  Name  |  Description  |  Default value  |
  |-----------------------|------------------------------|--------------------------------|
- |`CC_ELIXIR_VERSION` | Choose the Elixir version between `1.8`, `1.9`, `1.10`, `1.11`, `1.12`, `1.13` or `1.14` | 1.11 |
+ |`CC_ELIXIR_VERSION` | Choose the Elixir version between `1.8`, `1.9`, `1.10`, `1.11`, `1.12`, `1.13`, `1.14`, `1.15` or `1.16` | 1.16 |
  |`CC_MIX_BUILD_GOAL` | The mix goal to build the application (default compile) |  |
  |`CC_PHOENIX_ASSETS_DIR` | Folder in which your Phoenix assets are located. |  |
  |`CC_PHOENIX_DIGEST_GOAL` | Phoenix digest goal. | phx.digest |

--- a/static/partials/language-specific-deploy/elixir.md
+++ b/static/partials/language-specific-deploy/elixir.md
@@ -2,11 +2,11 @@
 
 ### Mandatory configuration
 
-- Get your Elixir version in your console with `$ elixir -v` and set the environment variable **CC_ELIXIR_VERSION** to its value (available versions as of today are `1.8`, `1.9`, `1.10`, `1.11`, `1.12`, `1.13` or `1.14`).  
+- Get your Elixir version in your console with `$ elixir -v` and set the environment variable **CC_ELIXIR_VERSION** to its value (available versions as of today are `1.8`, `1.9`, `1.10`, `1.11`, `1.12`, `1.13`, `1.14`, `1.15` or `1.16`).  
 
 #### Compatibility between Elixir and Erlang/OTP
 
-- Each version of Elixir uses the most recent compatible version of Erlang, based on the compatibility table provided in the [official Elixir documentation](https://hexdocs.pm/elixir/1.12.3/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp).
+- Each version of Elixir uses the most recent compatible version of Erlang, based on the compatibility table provided in the [official Elixir documentation](https://hexdocs.pm/elixir/1.16.1/compatibility-and-deprecations.html#between-elixir-and-erlang-otp).
 
 #### If you deploy a Phoenix application
 


### PR DESCRIPTION
## Describe your PR

Versions 1.15 and 1.6 are now available.

