### PR TITLE
fix(main-menu): change the link leading to the clever-components storybook

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -101,7 +101,7 @@ menu:
       weight: 4
     - identifier: components
       name: Web Components
-      url: "https://www.clever-cloud.com/doc/clever-components/?path=/story/readme--page"
+      url: "https://www.clever-cloud.com/doc/clever-components/"
       weight: 5
     - name: Search
       weight: 6


### PR DESCRIPTION
## Describe your PR

The frontend team recently migrated to Storybook 7 which changed URLs related to some docs.
The docs website's link to clever-components storybook referred to the `readme` page of the Storybook, which URL has changed.

This PR fixes the URL leading to the clever-components storybook.

**Note**: 
I've set the URL to the exact domain+path of the Storybook app root so that we don't have to change it everytime we change the name of our readme doc or its path.

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](../CONTRIBUTING.md)


## Reviewes
@juliamrch :innocent: 

