### PR TITLE
fix(apiv2-page): prevent conflicts with the global "/" shortcut

### DIFF
--- a/layouts/openapi/single.html
+++ b/layouts/openapi/single.html
@@ -29,6 +29,26 @@
             }
             });
           </script>
+          <script defer>
+            /** 
+             * FIXME: 
+             * This is a temporary solution to an issue caused by 3rd party scripts.
+             * Once they fix the issue, we should remove this.
+             *
+             * see https://github.com/CleverCloud/documentation/issues/218 for more info
+             */
+            document.addEventListener("DOMContentLoaded", (event) => {
+              const rapiDocElement = document.getElementById('api-doc');
+              rapiDocElement.addEventListener('keydown', (event) => {
+                const formElementTagNames = ['INPUT', 'SELECT', 'TEXTAREA', 'BUTTON'];
+                const triggerElement = event.composedPath()[0];
+                
+                if (formElementTagNames.includes(triggerElement.tagName)) {
+                  event.stopPropagation();
+                }
+              });
+            })
+          </script>
       </main>
     </article>
   </div>


### PR DESCRIPTION
Fixes #218

## Describe your PR

This PR fixes the following issue:

> On the [API v2 page](https://developers.clever-cloud.com/api/v2/), when you type "/" within the filter input field on the left, the focus is moved to the global search input.

It's  a quick fix to an issue caused by 3rd party scripts (`flexSearch` coming from the `Hextra` template).
I'll create an issue + PR on the `Hextra` repo when I have time :wink:  

## How to review

1. Go to the [API v2 preview page](http://doc-review-pr-219.cleverapps.io/api/v2/),
2. Try to type "/" within the filter input field on the left, it should type the "/" as expected,
3. Click somewhere within the page content (not on a button and not on an input),
4. Type "/" again, the focus should be moved to the global search input :tada: 

## Checklist

- [x] My PR is related to an opened issue : #218 
- [x] I've read the [contributing guidelines](../CONTRIBUTING.md)


## Reviewes

@juliamrch 