### PR TITLE
fix(docs/domain-names): remove auto monitoring mention

### DIFF
--- a/content/doc/administrate/domain-names.md
+++ b/content/doc/administrate/domain-names.md
@@ -48,8 +48,6 @@ You can point your domain name to Clever Cloud either with a CNAME record or wit
 With a CNAME record, your DNS configuration is always up-to-date.
 Using A records will require you to keep the DNS configuration up-to-date manually.
 
-Domain names linked to Clever Cloud applications are monitored, so we will send you an email if your DNS configuration is obsolete or incorrect.
-
 We also support wildcard personal domain names, to do so use the standard pattern to describe it: `*.example.com`
 
 ### Your Application Runs in the Europe/Paris ('PAR') Zone


### PR DESCRIPTION
## Describe your PR

This PR removes the following mention from the [Domain names doc page](https://developers.clever-cloud.com/doc/administrate/domain-names/#using-personal-domain-names):

> Domain names linked to Clever Cloud applications are monitored, so we will send you an email if your DNS configuration is obsolete or incorrect

This mention should be removed because this feature does not exist at the moment.

## How to review?

1. Go to [Using Personal Domain Names section - Domain Names - Preview](http://doc-review-pr-241.cleverapps.io/doc/administrate/domain-names/#using-personal-domain-names),
2. The mention should be gone.

This change has been approved by the traffic team :wink:

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](../CONTRIBUTING.md)


## Reviewes

@juliamrch
