### PR TITLE
Fix wordpress documentation regarding mysql non-default port.

### DIFF
--- a/content/guides/tutorial-wordpress.md
+++ b/content/guides/tutorial-wordpress.md
@@ -47,7 +47,7 @@ define( 'DB_HOST', getenv("MYSQL_ADDON_HOST").':'.getenv("MYSQL_ADDON_PORT") );
 ```
 
 {{< callout type="warning" >}}
-**Make sure you use the port we give you** in `wp-config.php`! Use the `MYSQL_ADDON_PORT` environment variable for that. We do **not** use the default MySQL port.
+**Make sure you use ** in `wp-config.php` the port the add-on dashboard provides. Use the `MYSQL_ADDON_PORT` environment variable for that. We **don't** use the default MySQL port.
 {{< /callout >}}
 
 ### SSL Configuration

--- a/content/guides/tutorial-wordpress.md
+++ b/content/guides/tutorial-wordpress.md
@@ -47,7 +47,7 @@ define( 'DB_HOST', getenv("MYSQL_ADDON_HOST").':'.getenv("MYSQL_ADDON_PORT") );
 ```
 
 {{< callout type="warning" >}}
-Excepting MySQL DEV plan, you have to figure the port out in `wp-config.php` with the environment variable `MYSQL_ADDON_HOST` because it is not the default port which is used.
+**Make sure you use the port we give you** in `wp-config.php`! Use the `MYSQL_ADDON_PORT` environment variable for that. We do **not** use the default MySQL port.
 {{< /callout >}}
 
 ### SSL Configuration


### PR DESCRIPTION
## Describe your PR

Since a few month ago, the MySQL DEV cluster does not listen on 3306 anymore.
Also, the documentation should not encourage using the default MySQL port at all.


## Checklist

- [x] I've read the [contributing guidelines](../CONTRIBUTING.md)
