### PR TITLE
doc: fix link to contributing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ _Summarize your changes here : explain what, how, and why. Be as explicict as yo
 ## Checklist
 
 - [ ] My PR is related to an opened issue : #
-- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)
+- [ ] I've read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
 
 
 ## Reviewes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,6 @@ _Summarize your changes here : explain what, how, and why. Be as explicict as yo
 - [ ] I've read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
 
 
-## Reviewes
+## Reviewers
 _Who should review these changes?_ @
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ _Summarize your changes here : explain what, how, and why. Be as explicict as yo
 ## Checklist
 
 - [ ] My PR is related to an opened issue : #
-- [ ] I've read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
+- [ ] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
 
 
 ## Reviewers


### PR DESCRIPTION

## Describe your PR

Depending where we are, the link can lead to a 404.

in example, in an open issue, since there's no "/blob/main" in the url, the link is broken


## Checklist

- [ ] I've read the [contributing guidelines](../CONTRIBUTING.md)


## Reviewes
_Who should review these changes?_ @

