### PR TITLE
[Starter Guide - Ruby] puma gem is mandatory

### DIFF
--- a/content/guides/ruby-rack-app-tutorial.md
+++ b/content/guides/ruby-rack-app-tutorial.md
@@ -71,6 +71,9 @@ The `gems.rb` or `Gemfile` file will contain our dependencies:
 source 'https://rubygems.org'
 
 gem 'rack', '~>1.5.1'
+
+
+gem "puma", "~> 6.4"
 ```
 
 We don't need any more dependencies. The `gems.rb` or `Gemfile` is mandatory to deploy
@@ -87,6 +90,7 @@ $ bundle install
 Fetching gem metadata from https://rubygems.org/..........
 Resolving dependencies...
 Using rack (1.5.2)
+Using puma (6.4.2)
 Using bundler (1.3.5)
 Your bundle is complete!
 Use `bundle show [gemname]` to see where a bundled gem is installed.


### PR DESCRIPTION
## Describe your PR

This PR adds puma dependency since I had to do it to get the Ruby tutorial working.  
Clever Cloud's deployment task explicitely asked for puma : 
```
[...]
2024-04-28T21:36:26+02:00 No Clever Cloud specific configuration file detected. Continuing…
2024-04-28T21:36:31+02:00 Use ruby 3.3.1
2024-04-28T21:36:33+02:00 puma requested but not present in Gemfile.lock, please run 'bundle add puma'
```

After adding puma :  


```
[...]
2024-04-28T21:37:58+02:00 Use ruby 3.3.1
2024-04-28T21:38:00+02:00 Fetch the dependencies, if you encounters any issue, set 'CC_RUBY_LEGACY' to 'true'
2024-04-28T21:38:03+02:00 Fetching nio4r 2.7.1
2024-04-28T21:38:03+02:00 Installing nio4r 2.7.1 with native extensions
2024-04-28T21:38:03+02:00 Fetching gem metadata from https://rubygems.org/..
2024-04-28T21:38:08+02:00 Fetching puma 6.4.2
2024-04-28T21:38:08+02:00 Installing puma 6.4.2 with native extensions
2024-04-28T21:38:14+02:00 Fetching rack 1.5.5
2024-04-28T21:38:15+02:00 Installing rack 1.5.5
2024-04-28T21:38:15+02:00 Bundle complete! 2 Gemfile dependencies, 4 gems now installed.
2024-04-28T21:38:15+02:00 Bundled gems are installed into `./vendor/bundle`
2024-04-28T21:38:15+02:00 Creating build cache archive
2024-04-28T21:38:15+02:00 Gems in the groups 'development' and 'test' were not installed.
2024-04-28T21:38:15+02:00 Created symlink /etc/systemd/system/multi-user.target.wants/nginx.service → /usr/x86_64-pc-linux-gnu/lib/systemd/system/nginx.service.
2024-04-28T21:38:15+02:00 Running as unit: bas-deploy.service; invocation ID: 3d4b9b50e66042a5a748e8a318370590
2024-04-28T21:38:15+02:00 build cache archive successfully created
2024-04-28T21:38:15+02:00 nginx: [warn] could not build optimal types_hash, you should increase either types_hash_max_size: 1024 or types_hash_bucket_size: 64; ignoring types_hash_bucket_size
2024-04-28T21:38:18+02:00 [2977] ! Consider running Puma in single-mode (workers = 0) in order to reduce memory overhead.
2024-04-28T21:38:18+02:00 [2977] Use Ctrl-C to stop
2024-04-28T21:38:18+02:00 [2977] - Worker 0 (PID: 3008) booted in 0.02s, phase: 0
2024-04-28T21:38:18+02:00 [2977] ! Running Puma in cluster mode with a single worker is often a misconfiguration.
2024-04-28T21:38:18+02:00 [2977] * Master PID: 2977
2024-04-28T21:38:18+02:00 [2977] * Max threads: 1
2024-04-28T21:38:18+02:00 [2977] * Min threads: 1
2024-04-28T21:38:18+02:00 [2977] * Puma version: 6.4.2 (ruby 3.3.1-p55) ("The Eagle of Durango")
2024-04-28T21:38:18+02:00 [2977] Puma starting in cluster mode...
2024-04-28T21:38:18+02:00 [2977] * Restarts: (✔) hot (✔) phased
2024-04-28T21:38:18+02:00 [2977] * Workers: 1
2024-04-28T21:38:18+02:00 [2977] ! WARNING: Detected running cluster mode with 1 worker.
2024-04-28T21:38:18+02:00 [2977] * Listening on unix:///run/puma/puma.sock
2024-04-28T21:38:18+02:00 [2977] * Environment: production
2024-04-28T21:38:18+02:00 [2977] ! Set the `silence_single_worker_warning` option to silence this warning message.
2024-04-28T21:38:23+02:00 No cron to setup
2024-04-28T21:38:23+02:00 Created symlink /etc/systemd/system/multi-user.target.wants/zabbix-agentd.service → /usr/x86_64-pc-linux-gnu/lib/systemd/system/zabbix-agentd.service.
2024-04-28T21:38:23+02:00 Application start successful
```

## Checklist
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [ ] My PR is related to an opened issue : No, I couldn't open an issue about something to fix in current documentation  
![image](https://github.com/CleverCloud/documentation/assets/101399296/7aa1bb24-5786-4d30-b7a7-09548e311bf3)


## Reviewers
_Who should review these changes?_ @LostInBrittany could :smiley: 

