### PR TITLE
change the default value of CGI implem to proxy_fcgi

### DIFF
--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -218,7 +218,7 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 |-----------------------|------------------------------|--------------------------------|
 |`ALWAYS_POPULATE_RAW_POST_DATA` |  |  |
 |`CC_COMPOSER_VERSION` | Choose your composer version between 1 and 2 | 2 |
-|[`CC_CGI_IMPLEMENTATION`](/doc/applications/php/#development-dependencies "Speed up or disable the session on FS Bucket") | Choose the Apache FastCGI module between fastcgi and proxy_fcgi | fastcgi |
+|[`CC_CGI_IMPLEMENTATION`](/doc/applications/php/#development-dependencies "Speed up or disable the session on FS Bucket") | Choose the Apache FastCGI module between fastcgi and proxy_fcgi | proxy_fcgi |
 |`CC_HTTP_BASIC_AUTH` | Restrict HTTP access to your application. Example: `login:password`. You can define multiple credentials using additional `CC_HTTP_BASIC_AUTH_n` (where `n` is a number) environment variables. |  |
 |`CC_LDAP_CA_CERT` |  |  |
 |`CC_MTA_AUTH_PASSWORD` | Password to authenticate to the SMTP server |  |


### PR DESCRIPTION
## Describe your PR

Modify the default value of CC_CGI_IMPLEMENTATION to `proxy_fcgi` in order to be relevant with the CC PHP documention.


## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


