### PR TITLE
"SSH key management" page - Dead link update 

### DIFF
--- a/content/doc/administrate/ssh-clever-tools.md
+++ b/content/doc/administrate/ssh-clever-tools.md
@@ -35,7 +35,7 @@ You need to have at least one of the following installed locally:
 
 ### Make sure you have a properly configured SSH key
 
-To use SSH access, you need to have a SSH key properly configured in your Clever Cloud account. Please refer to [the SSH keys section of the documentation](/doc/account/ssh-keys-managmenent) to know how to set up your SSH keys.
+To use SSH access, you need to have a SSH key properly configured in your Clever Cloud account. Please refer to [the SSH keys section of the documentation](/doc/account/ssh-keys-management) to know how to set up your SSH keys.
 
 ## Using Clever Tools CLI
 

--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -90,7 +90,7 @@ You can make the docker socket available from inside the container by adding the
 We support pulling private images through the `docker build` command. To login to a private registry, you need to set a few environment variables:
 
 * `CC_DOCKER_LOGIN_USERNAME`: the username to use to login
-* `CC_DOCKER_LOGIN_PASSWORD`: the password of your username
+* `CC_DOCKER_LOGIN_PASSWORD`: the password of your username
 * `CC_DOCKER_LOGIN_SERVER` (optional): the server of your private registry. Defaults to Docker's public registry.
 
 This uses the `docker login` command under the hood.


### PR DESCRIPTION
## Fixing typo causing a dead link
Page: [Lien](https://developers.clever-cloud.com/doc/administrate/ssh-clever-tools/#make-sure-you-have-a-properly-configured-ssh-key)
- Old broken link: https://developers.clever-cloud.com/doc/account/ssh-keys-managmenent
- New updated link: https://developers.clever-cloud.com/doc/account/ssh-keys-management


## Checklist

- [X ] My PR is related to an opened issue : #287 
- [X ] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
@cnivolle 
@juliamrch 

