### PR TITLE
Document usage of CC_HEALTH_CHECK_PATH in blue-green deployment.

### DIFF
--- a/content/doc/best-practices/blue-green.md
+++ b/content/doc/best-practices/blue-green.md
@@ -31,7 +31,7 @@ There are many benefits to this approach:
 
 When you push your source code to the Clever Cloud git remote, Clever Cloud will automatically use the "Blue/Green" pattern to apply your changes to your production.
 
-A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the server answers on :8080/ with a non error code. And that's it, you will use the new version on production within seconds.
+A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the [deployment healtcheck](https://developers.clever-cloud.com/doc/develop/healthcheck/) is succesful. And that's it, you will use the new version on production within seconds.
 
 If you push new changes, a *Green* VM will be created.
 

--- a/content/doc/best-practices/blue-green.md
+++ b/content/doc/best-practices/blue-green.md
@@ -31,7 +31,7 @@ There are many benefits to this approach:
 
 When you push your source code to the Clever Cloud git remote, Clever Cloud will automatically use the "Blue/Green" pattern to apply your changes to your production.
 
-A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the [deployment healtcheck](https://developers.clever-cloud.com/doc/develop/healthcheck/) is successful. And that's it, you will use the new version on production within seconds.
+A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the [deployment healthcheck](https://developers.clever-cloud.com/doc/develop/healthcheck/) is successful. And that's it, you will use the new version on production within seconds.
 
 If you push new changes, a *Green* VM will be created.
 

--- a/content/doc/best-practices/blue-green.md
+++ b/content/doc/best-practices/blue-green.md
@@ -31,7 +31,7 @@ There are many benefits to this approach:
 
 When you push your source code to the Clever Cloud git remote, Clever Cloud will automatically use the "Blue/Green" pattern to apply your changes to your production.
 
-A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the [deployment healtcheck](https://developers.clever-cloud.com/doc/develop/healthcheck/) is succesful. And that's it, you will use the new version on production within seconds.
+A new VM, let's call it *Blue* is created. The deployment is successful when there's no error in the build phase and the [deployment healtcheck](https://developers.clever-cloud.com/doc/develop/healthcheck/) is successful. And that's it, you will use the new version on production within seconds.
 
 If you push new changes, a *Green* VM will be created.
 

--- a/layouts/shortcodes/content/url_healthcheck.md
+++ b/layouts/shortcodes/content/url_healthcheck.md
@@ -17,7 +17,7 @@ CC_HEALTH_CHECK_PATH_1=/my/other/path
 
 The deployment process checks all paths. All of them must reply with a `200 OK` response code.
 
-By default, when no environment variable is defined, the root path `/` will be checked.
+By default, when no [environment variable](/doc/reference/reference-environment-variables) (for ex: `APP_HOME`) is defined, the monitoring checks your repository root path `/`.
 
 ### Example
 

--- a/layouts/shortcodes/content/url_healthcheck.md
+++ b/layouts/shortcodes/content/url_healthcheck.md
@@ -17,6 +17,8 @@ CC_HEALTH_CHECK_PATH_1=/my/other/path
 
 The deployment process checks all paths. All of them must reply with a `200 OK` response code.
 
+When no envrionment variable is defined the default is to get the root path, `/`.
+
 ### Example
 
 Using the path listed above, below are the expected logs:

--- a/layouts/shortcodes/content/url_healthcheck.md
+++ b/layouts/shortcodes/content/url_healthcheck.md
@@ -17,7 +17,7 @@ CC_HEALTH_CHECK_PATH_1=/my/other/path
 
 The deployment process checks all paths. All of them must reply with a `200 OK` response code.
 
-When no envrionment variable is defined the default is to get the root path, `/`.
+By default, when no environment variable is defined, the root path `/` will be checked.
 
 ### Example
 


### PR DESCRIPTION
## Describe your PR

Blue-green deployment refer to `8080/` to test the health of the system. However, `CC_HEALTH_CHECK_PATH` is more powerful.

This PR will add a reference to the health check page from the blue-green one. And document the default behavior of this health check.


## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
@juliamrch , @cnivolle , @adumas37 

