### PR TITLE
doc: add demo video to quickstart page

### DIFF
--- a/content/doc/quickstart/_index.md
+++ b/content/doc/quickstart/_index.md
@@ -88,6 +88,8 @@ The log system retrieves all output from the application and displays it in the 
 
 ### Create an Application Step by Step
 
+{{< youtube 9ww_t0o-GmA >}}
+
 In the [Clever Cloud Console](https://console.clever-cloud.com/):
 
 {{% steps %}}


### PR DESCRIPTION
## Describe your PR

This PR adds the video tutorial in Quickstart section, by embedding it from Youtube, following [the native Hugo feature for external media content](https://gohugo.io/content-management/shortcodes/#youtube).

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @cnivolle: what do you think of the location of the video? I'm not sure if it's appropriate. 

