### PR TITLE
fix new relics documentation links in shortcodes layout

### DIFF
--- a/layouts/shortcodes/content/new-relic.md
+++ b/layouts/shortcodes/content/new-relic.md
@@ -2,4 +2,4 @@
 
 You can use [New Relic](https://www.newrelic.com/) to monitor your application on Clever Cloud.
 
-Please refer to our [New Relic documentation](doc/metrics/new-relic) to configure it for your application.
+Please refer to our [New Relic documentation](/doc/metrics/new-relic) to configure it for your application.


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : Several pages use the shortcodes layout of new relics to link to our new relics documentation.
The link had a problem and sent to a 404 pages.
Fixed the links so that it should work.


## Checklist

- [x] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @

