### PR TITLE
Add warning on installing clever tools with apple processor

### DIFF
--- a/content/doc/CLI/getting_started.md
+++ b/content/doc/CLI/getting_started.md
@@ -123,8 +123,8 @@ NOTES:
 
 {{< callout type="warning" >}}
 If you have an apple processor, an error may occur during the installation.  
-This is because clever tools currently only work on MacOS with an intel processor.
-To resolve this problem, you can install Rosetta, a program that let apple processor run program made for intel.  
+This is because clever tools currently only work on MacOS with an Intel processor.
+To resolve this problem, you can install Rosetta, a program that let apple processor run program made for Intel.  
 To install it, you can use the command `/usr/sbin/softwareupdate --install-rosetta`
 {{< /callout >}}
 

--- a/content/doc/CLI/getting_started.md
+++ b/content/doc/CLI/getting_started.md
@@ -121,6 +121,13 @@ NOTES:
 
 ### On macOS
 
+{{< callout type="warning" >}}
+If you have an apple processor, an error may occur during the installation.  
+This is because clever tools currently only work on MacOS with an intel processor.
+To resolve this problem, you can install Rosetta, a program that let apple processor run program made for intel.  
+To install it, you can use the command `/usr/sbin/softwareupdate --install-rosetta`
+{{< /callout >}}
+
 #### Using homebrew
 
 If you are using macOS and you have [homebrew](https://brew.sh) installed, you can run:

--- a/content/doc/CLI/getting_started.md
+++ b/content/doc/CLI/getting_started.md
@@ -122,7 +122,7 @@ NOTES:
 ### On macOS
 
 {{< callout type="warning" >}}
-If you have an apple processor, an error may occur during the installation.  
+If you have an Apple processor, an error may occur during the installation.  
 This is because clever tools currently only work on MacOS with an Intel processor.
 To resolve this problem, you can install Rosetta, a program that lets Apple processors run programs compiled for Intel processors.  
 To install it, you can use the command `/usr/sbin/softwareupdate --install-rosetta`

--- a/content/doc/CLI/getting_started.md
+++ b/content/doc/CLI/getting_started.md
@@ -124,7 +124,7 @@ NOTES:
 {{< callout type="warning" >}}
 If you have an apple processor, an error may occur during the installation.  
 This is because clever tools currently only work on MacOS with an Intel processor.
-To resolve this problem, you can install Rosetta, a program that let apple processor run program made for Intel.  
+To resolve this problem, you can install Rosetta, a program that lets Apple processors run programs compiled for Intel processors.  
 To install it, you can use the command `/usr/sbin/softwareupdate --install-rosetta`
 {{< /callout >}}
 


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : 
User with a MacOS that have an apple processor will have the error `Bad CPU type in executable` during clever-tools installation.  
The problem can be easily solved by installing [Rosetta](https://support.apple.com/fr-fr/102527)  
I added a warning at the MacOS section to specify the need of Rosetta in this case and a command to install it.


## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @

