### PR TITLE
Use Varnish in a monorepo

### DIFF
--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -65,7 +65,7 @@ If you have a `/clevercloud/varnish.vcl` file at the root of your monorepo, all 
 
 To resolve this issue, you can create a symlink during the deployments.  
 First, you need to put your `varnish.vcl` file anywhere but at the root of your monorepo.  
-Then, you need to create a symlink inside a `CC_PRE_RUN_HOOK`.  
+Then, you need to create a symlink inside a `CC_PRE_BUILD_HOOK`.  
 Here is an example :
 
 ```bash

--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -65,7 +65,8 @@ If you have a `/clevercloud/varnish.vcl` file at the root of your monorepo, all 
 
 To resolve this issue, you can create a symlink during the deployments.  
 First, you need to put your `varnish.vcl` file anywhere but at the root of your monorepo.  
-Then, you need to create a symlink inside a `CC_PRE_BUILD_HOOK`.  
+2. Create a symlink inside a `CC_PRE_BUILD_HOOK`.
+  
 Here is an example :
 
 ```bash

--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -72,4 +72,4 @@ Here is an example :
 CC_PRE_BUILD_HOOK="mkdir $APP_HOME/clevercloud; ln -s $APP_HOME/path/to/your/file/varnish.vcl $APP_HOME/clevercloud/varnish.vcl"
 ```
 
-This way, you only need to add the `CC_PRE_RUN_HOOK` when you want your app to use Varnish. If you don't, the application won't use it.
+This way, you only need to add the `CC_PRE_BUILD_HOOK` when you want your app to use Varnish. If you don't, the application won't use it.

--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -74,4 +74,4 @@ Here is an example :
 CC_PRE_BUILD_HOOK="mkdir $APP_HOME/clevercloud; ln -s $APP_HOME/path/to/your/file/varnish.vcl $APP_HOME/clevercloud/varnish.vcl"
 ```
 
-This way, you only need to add the `CC_PRE_BUILD_HOOK` when you want your app to use Varnish. If you don't, the application won't use it.
+Then add the `CC_PRE_BUILD_HOOK` as a variable to the app that needs to use Varnish. If you don't add this variable, the application won't use it.

--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -57,3 +57,19 @@ If you already have a configuration for an older version of varnish, you can rea
 We provide some [examples of Varnish configuration files](https://GitHub.com/CleverCloud/varnish-examples) that you can
 use for your application. Create a `/clevercloud` folder at the root of your application if it does not exist,
 rename the file to `varnish.vcl` and move it in the `/clevercloud` folder.
+
+## Varnish with a monorepo
+
+If you use a monorepo, you may want to use Varnish for only some of the applications inside it.  
+If you have a `/clevercloud/varnish.vcl` file at the root of your monorepo, all of your applications automatically start using Varnish.
+
+To resolve this issue, you can create a symlink during the deployments.  
+First, you need to put your `varnish.vcl` file anywhere but at the root of your monorepo.  
+Then, you need to create a symlink inside a `CC_PRE_RUN_HOOK`.  
+Here is an example :
+
+```bash
+CC_PRE_RUN_HOOK="mkdir $APP_HOME/clevercloud; ln -s $APP_HOME/path/to/your/file/varnish.vcl $APP_HOME/clevercloud/varnish.vcl"
+```
+
+This way, you only need to add the `CC_PRE_RUN_HOOK` when you want your app to use Varnish. If you don't, the application won't use it.

--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -64,7 +64,8 @@ If you use a monorepo, you may want to use Varnish for only some of the applicat
 If you have a `/clevercloud/varnish.vcl` file at the root of your monorepo, all of your applications automatically start using Varnish.
 
 To resolve this issue, you can create a symlink during the deployments.  
-First, you need to put your `varnish.vcl` file anywhere but at the root of your monorepo.  
+
+1. Put your `varnish.vcl` file anywhere but at the root of your monorepo.  
 2. Create a symlink inside a `CC_PRE_BUILD_HOOK`.
   
 Here is an example :

--- a/content/doc/administrate/cache.md
+++ b/content/doc/administrate/cache.md
@@ -69,7 +69,7 @@ Then, you need to create a symlink inside a `CC_PRE_RUN_HOOK`.
 Here is an example :
 
 ```bash
-CC_PRE_RUN_HOOK="mkdir $APP_HOME/clevercloud; ln -s $APP_HOME/path/to/your/file/varnish.vcl $APP_HOME/clevercloud/varnish.vcl"
+CC_PRE_BUILD_HOOK="mkdir $APP_HOME/clevercloud; ln -s $APP_HOME/path/to/your/file/varnish.vcl $APP_HOME/clevercloud/varnish.vcl"
 ```
 
 This way, you only need to add the `CC_PRE_RUN_HOOK` when you want your app to use Varnish. If you don't, the application won't use it.


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : Some user may decide to use a monorepo, that means that they may have multiple applications inside one repository.  
In some case, they may want to use Varnish only for some applications, and not all of them.    
The current implementation of Varnish where you need to have a `/clevercloud/varnish.vcl` file at the root cause problem because Varnish would automatically be used with all the app.  
There is a way to resolve that problem by not putting the `varnish.vcl` file at the the root and creating a symlink using deployments hooks.

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @

