### PR TITLE
doc: document drain log to Logs Data Platform on OVH

### DIFF
--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -248,7 +248,8 @@ On your terminal, use the following command:
   ```shell
   clever drain create TCPSyslog tcp://<host>:514 -app <application-id-or-name> --sd-params="X-OVH-TOKEN=\"<token>\""
   Replace the following values:
-    
+  ```
+  
   - `<host>`
   - `<application-alias>`
   - `<token>`

--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -247,7 +247,6 @@ On your terminal, use the following command:
     
   ```shell
   clever drain create TCPSyslog tcp://<host>:514 -app <application-id-or-name> --sd-params="X-OVH-TOKEN=\"<token>\""
-  
   Replace the following values:
     
   - `<host>`

--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -247,8 +247,9 @@ On your terminal, use the following command:
     
   ```shell
   clever drain create TCPSyslog tcp://<host>:514 -app <application-id-or-name> --sd-params="X-OVH-TOKEN=\"<token>\""
-  Replace the following values:
   ```
+  
+  Replace the following values:
   
   - `<host>`
   - `<application-alias>`

--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -246,8 +246,7 @@ On your terminal, use the following command:
   {{< tab >}}**Exporting logs from an application**:
     
   ```shell
-  clever drain create TCPSyslog tcp://<host>:514 -a <application-alias> --sd-params="X-OVH-TOKEN=\"<token>\""
-  ```
+  clever drain create TCPSyslog tcp://<host>:514 -app <application-id-or-name> --sd-params="X-OVH-TOKEN=\"<token>\""
   
   Replace the following values:
     

--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -221,7 +221,7 @@ Datadog has two zones, **EU** and **COM**. An account on one zone is not availab
 
 ### NewRelic
 
-To create a [NewRelic](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/) drain, you just need to use:
+To create a [NewRelic](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/) drain, use:
 
 ```bash
 clever drain create NewRelicHTTP "https://log-api.eu.newrelic.com/log/v1" --api-key "<API_KEY>"
@@ -230,6 +230,48 @@ clever drain create NewRelicHTTP "https://log-api.eu.newrelic.com/log/v1" --api-
 {{< callout type="warning" >}}
 NewRelic has two zones, **EU** and **US**. An account on one zone is not available on the other, make sure to target the right intake endpoint (`log-api.eu.newrelic.com` or `log-api.newrelic.com`).
 {{< /callout >}}
+
+### OVH Logs Data Platform
+
+To export logs from an application or an add-on to [OVH Logs Data Platform](https://help.ovhcloud.com/csm/en-ie-logs-data-platform-quick-start?id=kb_article_view&sysparm_article=KB0055819), use the following setup:
+
+- A **TCP** drain log with `clever drain create TCPSyslog`
+- Your Logs Data Platform **host** with **port** `514` (SSL ports aren't supported for TCP drains)
+- The **write token** for your stream (provided on your Logs Data Platform console)
+
+On your terminal, use the following command:
+
+{{< tabs items="Application,Add-on" >}}
+
+  {{< tab >}}**Exporting logs from an application**:
+    
+  ```shell
+  clever drain create TCPSyslog tcp://<host>:514 -a <application-alias> --sd-params="X-OVH-TOKEN=\"<token>\""
+  ```
+  
+  Replace the following values:
+    
+  - `<host>`
+  - `<application-alias>`
+  - `<token>`
+
+  {{< /tab >}}
+
+  {{< tab >}}**Exporting logs from an add-on**:
+  
+  ```shell
+  clever drain create TCPSyslog tcp://<host>:514 -addon <addon_id> --sd-params="X-OVH-TOKEN=\"<token>\""
+  ```
+  
+  Replace the following values:
+    
+  - `<host>`
+  - `<addon_id>`
+  - `<token>`
+  
+  {{< /tab >}}
+
+{{< /tabs >}}
 
 ### Community software
 


### PR DESCRIPTION
## Describe your PR

The ability to export logs using authentication has been added to the CLI, especially for customers requesting help to store and stream logs on Logs Data Platform (OVH service).

This update documents the command and set up needed to do so.


## Checklist

- [x] My PR is related to an opened issue : #284 
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @pdesoyres-cc would you try it out and tell where the doc is lacking, eventually?

