### PR TITLE
Hugo version setup

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -32,7 +32,7 @@ jobs:
           GH_CC_WEBROOT: '/public'
           GH_HEXTRA_VERSION: 'v0.8.2'
           GH_HUGO_ENV: 'production'
-          GH_HUGO_VERSION: '0.133.0'
+          GH_HUGO_VERSION: '0.133.1'
         with:
           type: 'static-apache'
           set-env: true

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cnivolle/hextra //to update
+module github.com/CleverCloud/documentation
 
 go 1.21
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -9,6 +9,11 @@ enableGitInfo: true
 module:
   imports:
     - path: github.com/imfing/hextra
+  hugoVersion:
+    extended: true
+    min: "0.133.0"
+    max: "0.133.1"
+
 outputs:
   home: [HTML]
   page: [HTML]


### PR DESCRIPTION
## Describe your PR

This chore configuration sets a minimum (`0.133.0`) and a maximum (`0.133.1`) Hugo version. The minimum is based on potential breaking changes and the maximum is the last tested one.

This solves local errors depending on the installed Hugo version installed across contributors machines. If the installed version is out of scope, the following warning will print:

```shell
WARN  Module "github.com/CleverCloud/documentation" is not compatible with this Hugo version: 0.133.0/0.133.1
```

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @Kirbeerus could you tell me if this change would be helpful enough for this kind of errors?

