### PR TITLE
chore: upgrade from version 0.133.1 to version 0.134.1

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -33,7 +33,7 @@ jobs:
           GH_CC_WEBROOT: '/public'
           GH_HEXTRA_VERSION: 'v0.8.2'
           GH_HUGO_ENV: 'production'
-          GH_HUGO_VERSION: '0.133.1'
+          GH_HUGO_VERSION: '0.134.1'
         with:
           type: 'static-apache'
           set-env: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,7 +1,7 @@
 baseURL: https://developers.clever-cloud.com
 languageCode: en-us
 title: Clever Cloud Documentation
-paginate: 50 #Number of item to show in the changelog section before pagination
+pagination.pagerSize: 50 #Number of item to show in the changelog section before pagination
 
 enableRobotsTXT: true
 enableGitInfo: true
@@ -12,7 +12,7 @@ module:
   hugoVersion:
     extended: true
     min: "0.133.0"
-    max: "0.133.1"
+    max: "0.134.1"
 
 outputs:
   home: [HTML]


### PR DESCRIPTION

## Describe your PR

This updates the Hugo version to [v0.134.1](https://github.com/gohugoio/hugo/releases/tag/v0.134.1) (latest release) and fixes the `paginate` warning (deprecated since v0.128.0 and soon to be removed) to replace it by `pagination.pagerSize`.

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @Dekabry 

