### PR TITLE
changelog: fix typo and add breaking changes warning

### DIFF
--- a/content/changelog/2024-09-03-gitlab-components-review-apps.md
+++ b/content/changelog/2024-09-03-gitlab-components-review-apps.md
@@ -19,4 +19,4 @@ Some months ago, we released [a new GitLab Component](https://gitlab.com/explore
 
 **Breaking changes**: Input `deploy` have been removed to prevent users to script the environment variables injection before deploying the app. Remove it from your `.gitlab-ci.yml` file if it's set up, to avoid breaking your pipeline.
 
-- [Learn more about how to deploy from GitHub to Clever Cloud](/doc/ci-cd/gitlab/)
+- [Learn more about how to deploy from GitLab to Clever Cloud](/doc/ci-cd/gitlab/)

--- a/content/changelog/2024-09-03-gitlab-components-review-apps.md
+++ b/content/changelog/2024-09-03-gitlab-components-review-apps.md
@@ -15,6 +15,8 @@ description: Simplify your GitLab workflows
 excludeSearch: true
 ---
 
-Some months ago, we released [a new GitHub Component](https://gitlab.com/explore/catalog/CleverCloud/clever-cloud-pipeline) to deploy applications from GitLab to Clever Cloud. Version 2.0 is available with variables injection from GitLab CI/CD and automatic releases. You can now use the `latest` tag and input deploy have been removed to prevent users to script the environment variables injection before deploying the app.
+Some months ago, we released [a new GitLab Component](https://gitlab.com/explore/catalog/CleverCloud/clever-cloud-pipeline) to deploy applications from GitLab to Clever Cloud. Version 2.0 is available with variables injection from GitLab CI/CD and automatic releases. You can now use it with the `latest` tag for tests, or `2.0.1` tag for production.
+
+**Breaking changes**: Input `deploy` have been removed to prevent users to script the environment variables injection before deploying the app. Remove it from your `.gitlab-ci.yml` file if it's set up, to avoid breaking your pipeline.
 
 - [Learn more about how to deploy from GitHub to Clever Cloud](/doc/ci-cd/gitlab/)


### PR DESCRIPTION
## Describe your PR

- Replace `GitHub` by `GitLab`
- Add warning for breaking changes if users have set up `deploy` input, which no longer exists
- Specify the use cases for tags (`latest` for tests, version for prod) to avoid breaking pipelines lol 


## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @davlgd 

