### PR TITLE
chore: upgrade hugo v0.134.1 to v0.134.2

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -33,7 +33,7 @@ jobs:
           GH_CC_WEBROOT: '/public'
           GH_HEXTRA_VERSION: 'v0.8.2'
           GH_HUGO_ENV: 'production'
-          GH_HUGO_VERSION: '0.134.1'
+          GH_HUGO_VERSION: '0.134.2'
         with:
           type: 'static-apache'
           set-env: true

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -12,7 +12,7 @@ module:
   hugoVersion:
     extended: true
     min: "0.133.0"
-    max: "0.134.1"
+    max: "0.134.2"
 
 outputs:
   home: [HTML]


### PR DESCRIPTION
## Describe your PR

Upgrade Hugo version from v0.134.1 to [v0.134.2](https://github.com/gohugoio/hugo/releases/tag/v0.134.2). No notable changes since we don't use auto-summaries.


## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @Kirbeerus 

