### PR TITLE
doc: specify Docker image steps

### DIFF
--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -33,6 +33,20 @@ Clever Cloud allows you to deploy any application running inside a Docker contai
 [FS Buckets](/doc/best-practices/cloud-storage/#what-is-fs-bucket) access, Dockerfile validation, and Docker Compose functionalities are not supported.
 {{< /callout >}}
 
+### How it works
+
+When you create a Docker application on Clever Cloud, the deployment process involves the following steps:
+
+1. **Install/Login:**
+   - The system checks for a Dockerfile and an entrypoint.
+   - It logs into the appropriate registry if necessary.
+2. **Build:**
+   - The application pulls the specified image an execute commands you specified in Dockerfile.
+   - **Note:** This step focuses on executing commands in your Dockerfile and doesn't require build instructions if you are using a pre-compiled image.
+3. **Run:**
+   - The application starts in a Docker container and exposes the service on port 8080 by default.
+   - If you need to expose your application on a different port, you can specify this using the environment variable `CC_DOCKER_EXPOSED_HTTP_PORT`.
+
  {{% content/set-env-vars %}}
 
 ## Configure your Docker application

--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -39,7 +39,7 @@ When you create a Docker application on Clever Cloud, the deployment process inv
 
 1. **Install/Login:**
    - The system checks for a Dockerfile and an entrypoint.
-- It logs into the docker registry that was configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the docker registry may vary depending on the provider. It is called "container registry" in Github, for instance)
+  - It logs into the docker registry that was configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the docker registry may vary depending on the provider. It is called "container registry" in Github, for instance)
 2. **Build:**
    - The application pulls the specified image and execute commands you specified in Dockerfile.
    - **Note:** This step focuses on executing commands in your Dockerfile and doesn't require build instructions if you are using a pre-compiled image.

--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -39,7 +39,7 @@ When you create a Docker application on Clever Cloud, the deployment process inv
 
 1. **Install/Login:**
    - The system checks for a Dockerfile and an entrypoint.
-   - It logs into the appropriate registry if necessary.
+- It logs into the docker registry that was configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the docker registry may vary depending on the provider. It is called "container registry" in Github, for instance)
 2. **Build:**
    - The application pulls the specified image and execute commands you specified in Dockerfile.
    - **Note:** This step focuses on executing commands in your Dockerfile and doesn't require build instructions if you are using a pre-compiled image.

--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -39,7 +39,7 @@ When you create a Docker application on Clever Cloud, the deployment process inv
 
 1. **Install/Login:**
    - The system checks for a Dockerfile and an entrypoint.
-    - It logs into the docker registry that was configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the Docker registry may vary depending on the provider. It is called "container registry" in GitHub, for instance)
+    - It logs into the docker registry that you configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the Docker registry may vary depending on the provider. It's called "container registry" in GitHub, for instance)
 2. **Build:**
    - The application pulls the specified image and execute commands you specified in Dockerfile.
    - **Note:** This step focuses on executing commands in your Dockerfile and doesn't require build instructions if you are using a pre-compiled image.

--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -39,7 +39,7 @@ When you create a Docker application on Clever Cloud, the deployment process inv
 
 1. **Install/Login:**
    - The system checks for a Dockerfile and an entrypoint.
-  - It logs into the docker registry that was configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the docker registry may vary depending on the provider. It is called "container registry" in Github, for instance)
+    - It logs into the docker registry that was configured in the Dockerfile, if any, to find the necessary image (**note:** the name of the Docker registry may vary depending on the provider. It is called "container registry" in GitHub, for instance)
 2. **Build:**
    - The application pulls the specified image and execute commands you specified in Dockerfile.
    - **Note:** This step focuses on executing commands in your Dockerfile and doesn't require build instructions if you are using a pre-compiled image.

--- a/content/doc/applications/docker/_index.md
+++ b/content/doc/applications/docker/_index.md
@@ -41,7 +41,7 @@ When you create a Docker application on Clever Cloud, the deployment process inv
    - The system checks for a Dockerfile and an entrypoint.
    - It logs into the appropriate registry if necessary.
 2. **Build:**
-   - The application pulls the specified image an execute commands you specified in Dockerfile.
+   - The application pulls the specified image and execute commands you specified in Dockerfile.
    - **Note:** This step focuses on executing commands in your Dockerfile and doesn't require build instructions if you are using a pre-compiled image.
 3. **Run:**
    - The application starts in a Docker container and exposes the service on port 8080 by default.


### PR DESCRIPTION
## Describe your PR

A few clients are confused by the `build` usage in our Docker doc. I've added a section in Docker doc to specify different steps and clarify what happens if no build is required (e.g. in a pre-compiled image use case).

### Preview

- [Docker doc](http://documentation-pr-379.cleverapps.io/doc/applications/docker/#how-it-works)

## Checklist

- [ ] My PR is related to an opened issue : # idk tbh but it should
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @BlackYoup wdyt

