### PR TITLE
changelog: python lifecycle

### DIFF
--- a/content/changelog/2024-10-01-python-image-changes.md
+++ b/content/changelog/2024-10-01-python-image-changes.md
@@ -1,0 +1,39 @@
+---
+title: "Python image: what's new and what's to come"
+date: 2024-10-01
+tags:
+  - images
+  - update
+authors:
+  - name: David Legrand
+    link: https://github.com/davlgd
+    image: https://github.com/davlgd.png?size=40
+description: uv, Python 3.13 and some clean up
+excludeSearch: true
+---
+
+Python ecosystem is diverse, with lots of legacy versions and practices. But in the recent months, it evolved on many fronts. So, we've decided to handle it and start to revise how you can deploy Python applications on Clever Cloud.
+
+## Package management: uv on Clever Cloud
+
+We only support [pip](https://packaging.python.org/en/latest/tutorials/installing-packages/), `requirements.txt` and `setup.py` natively. For some weeks, we've included [uv](https://docs.astral.sh/uv/getting-started/features/) in our Python image to make some tests. Based on Rust, this package and project manager is compliant with existing ecosystem and blazing fast. [It's now a part](/doc/applications/python/#use-uv-as-a-package-manager) of our "Enthusiast tools" initiative and will be updated regularly. Thus, there is no active support for it yet.
+
+We'll enhance its native support in coming releases of our Python image.
+
+* [Learn more about uv](https://github.com/astral-sh/uv) {{< icon "github" >}}
+
+## Python versions: time to clean up
+
+We're in 2024 and Python 2.x still coexists with Python 3.x. As it's always used by some of our customers, we've decided to continue to support it. Python 3.x is now the default version for new Python applications. We'll make this change for other runtimes (where Python is also included), starting 2025. If you need Python 2.x, set `CC_PYTHON_VERSION=2` in your applications.
+
+We'll also get closer to [the official Python release cycle](https://devguide.python.org/versions/#python-release-cycle), which is 5 years of support. Thus, we'll stop using Python 3.7 starting December 1st, 2024. Next year, we'll deprecate Python 3.8 and stop providing it. If an application is asking for a deprecated version, it will use the latest available by default. So, upgrade your `CC_PYTHON_VERSION` towards your needs.
+
+If you need to sideload unsupported Python versions, `uv` [can help you](https://docs.astral.sh/uv/guides/install-python/). You can also deploy your applications through [Docker](/doc/applications/docker), but you should avoid to use end of life runtime in your applications.
+
+* Learn more about [Python on Clever Cloud](/doc/applications/python/)
+
+## What's next?
+
+We'll enhance our Python images to better support modern Python ecosystem and simplify the deployment process. Python 3.13, [released today](https://docs.python.org/3.13/whatsnew/3.13.html), will be available on Clever Cloud in the coming weeks.
+
+If you have any questions or suggestions, feel free to tell us on [our community page](https://github.com/CleverCloud/Community/discussions/categories/paas-runtimes).

--- a/content/doc/applications/python/_index.md
+++ b/content/doc/applications/python/_index.md
@@ -2,7 +2,7 @@
 type: docs
 title: Python
 
-shortdesc: Python 2.7 and 3.11 are available on our platform. You can use Git to deploy your application.
+shortdesc: Python 2.7 and 3.12 are available on our platform. You can use git to deploy your application.
 tags:
 - deploy
 keywords:
@@ -24,7 +24,14 @@ Python is a programming language that lets you work more quickly and integrate y
 
 ### Supported Versions
 
+The default version of Python on Clever Cloud is the latest we support from branch `3.x`. If you want to use Python `2.x`, create an [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_PYTHON_VERSION` set to `2`, it will default to Python 2.7. Other supported values are :
+
 {{< runtimes_versions python >}}
+
+{{< callout type="warning" >}}
+Python 3.7 [is end of life since 27 June 2023](https://devguide.python.org/versions/#python-release-cycle), we considered it as deprecated. It will be removed from our images [starting December, 1st](/changelog/2024-10-01-python-image-changes/).\
+Latest 3.x version will be used after this date. To prevent this, upgrade your `CC_PYTHON_VERSION` towards your needs.
+{{< /callout >}}
 
 {{% content/create-application %}}
 
@@ -48,16 +55,15 @@ For example with *Flask*, it's gonna be the name of your main server file, follo
 
 You can also use `CC_RUN_COMMAND` to launch Python application your way. In such case, it must listen on port `9000`.
 
-### Choose Python version
+### Use uv as a package manager
 
-The default version of python on Clever Cloud is **2.7**. If you want to use python **3.x** instead, create an [environment variable](#setting-up-environment-variables-on-clever-cloud) `CC_PYTHON_VERSION` equal to either `3` (which will default to the most up-to-date version), `3.7`, `3.8`, `3.9`, `3.10` or `3.11`.
+Built in Rust, `uv` is a modern package and project manager for Python. It's fast to install dependencies, can be used as a drop-in replacement for `pip` and to sideload unsupported versions of Python. For example to use it with a `app.py` file, you just need to set `CC_RUN_COMMAND="uv run app.py"`. If your application listens on port `9000` with `0.0.0.0` as host, it will work fine on Clever Cloud.
 
-**Note**: the version is a number, do not use quotes. values allowed are `2`, `2.7`, `3`, `3.7`, `3.8`, `3.9`, `3.10`, `3.11`.
+* [Learn more about uv](https://github.com/astral-sh/uv)
 
-### Choose Pip version
-
-The default version of pip on Clever Cloud is **19**.
-If you want to use pip **9** instead, create an [environment variable](#setting-up-environment-variables-on-clever-cloud) like `CC_PIP_VERSION=9`.
+{{< callout type="info" >}}
+  `uv` is part of our Enthusiast tools initiative, it's included and can be used, but there is no active support for it yet.
+{{< /callout >}}
 
 ### Select the python backend
 

--- a/data/runtime_versions.yml
+++ b/data/runtime_versions.yml
@@ -19,8 +19,9 @@ python:
   default:
     - "3.12"
   accepted:
+    - "2"
     - "3"
-    - "3.7"
+    - "3.7 (deprecated)"
     - "3.8"
     - "3.9"
     - "3.10"


### PR DESCRIPTION
Add en entry about latest Python news and deprecation to come for `3.7`
+ doc update