### PR TITLE
Feat: automate external doc updates

### DIFF
--- a/.github/external-doc-issue.yml
+++ b/.github/external-doc-issue.yml
@@ -1,0 +1,8 @@
+---
+title: External doc
+labels: documentation
+---
+
+Update the external documentation.
+
+{{ payload.sender.login }}.

--- a/.github/external-doc-issue.yml
+++ b/.github/external-doc-issue.yml
@@ -1,8 +1,10 @@
 ---
-title: External doc
+title: External doc update from ${{ env.PR_NUMBER }}
 labels: documentation
 ---
 
-Update the external documentation.
+Update the external documentation:
 
-{{ payload.sender.login }}.
+- Author: '@${{ payload.sender.login }}'
+- PR: ${{ env.PR_URL }}
+- Modified files: ${{ env.CHANGED_FILES }}

--- a/.github/external-doc-issue.yml
+++ b/.github/external-doc-issue.yml
@@ -1,10 +1,18 @@
 ---
-title: External doc update from ${{ env.PR_NUMBER }}
+title: External doc update from PR {{ env.PR_NUMBER }}
 labels: documentation
 ---
 
+## External documentation update needed
+
 Update the external documentation:
 
-- Author: '@${{ payload.sender.login }}'
-- PR: ${{ env.PR_URL }}
-- Modified files: ${{ env.CHANGED_FILES }}
+- Author: @{{ payload.sender.login }}
+- PR: {{ env.PR_URL }}
+- Modified files: {{ env.CHANGED_FILES }}
+
+Make a PR on one of these repositories:
+
+- [Astro](https://github.com/withastro/docs)
+
+

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -2,7 +2,7 @@ name: Update external doc?
 
 on:
   pull_request_target:
-    types: [opened, closed, synchronize, reopened]
+    types: [opened, synchronize]
     branches: [ main ]
 
 jobs:
@@ -28,6 +28,7 @@ jobs:
           files: |
             content/guides/astro.md
       - name: Create issue
+        id: create-issue
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,27 +39,18 @@ jobs:
         with:
           filename: .github/external-doc-issue.yml
           assignees: ${{ github.event.pull_request.user.login }}
-        
-      - name: Run step if external doc has changed
-        if: steps.changed-files-specific.outputs.any_changed == 'true'
+          update_existing: false
+          search_existing: all
+      - name: Create or update a comment
         env:
           CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/github-script@v7
+        uses: taoliujun/action-unique-comment@v1
         with:
-          script: |
-            const issue_number = context.payload.pull_request.number;
-            const message = `You updated ${{ env.CHANGED_FILES }}.
-                
-                Update the external doc as well by making a PR on either:
+          uniqueIdentifier: ${{ github.workflow }}
+          body: |
+            You updated ${{ env.CHANGED_FILES }}. This content is also listed on external doc. Issue number ${{ steps.create-issue.outputs.number }} has been created has been created and asigned to you 🫵👁️👄👁️
             
-            * [Astro](https://github.com/withastro/docs).
-            * More to come ;)?
-            `;
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue_number,
-              body: message
-                });
+            See it or modify it here: 
+              * ${{ steps.create-issue.outputs.url }}
+
       

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   changed_files:
-    runs-on: ubuntu-latest  # windows-latest || macos-latest
+    runs-on: ubuntu-latest
     name: Test changed-files
-    permissions:
+    permissions: # Needed to post comments and create issues
         issues: write
         pull-requests: write
         contents: read
@@ -21,12 +21,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+      
+      # Check if any external doc needs an update
       - name: Get files linked to external doc
         id: changed-files-specific
         uses: tj-actions/changed-files@v45
         with:
           files: |
             content/guides/astro.md
+      
+      # Create issue and assign PR author
       - name: Create issue
         id: create-issue
         if: steps.changed-files-specific.outputs.any_changed == 'true'
@@ -41,6 +45,8 @@ jobs:
           assignees: ${{ github.event.pull_request.user.login }}
           update_existing: true
           search_existing: all
+      
+      # Post a single comment with auto-updating body
       - name: Create or update a comment
         env:
           CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           uniqueIdentifier: ${{ github.workflow }}
           body: |
-            You updated ${{ env.CHANGED_FILES }}. This content is also listed on external doc. Issue number ${{ steps.create-issue.outputs.number }} has been created has been created and asigned to you 🫵👁️👄👁️
+            You updated ${{ env.CHANGED_FILES }}. This content is also listed on external doc. Issue number ${{ steps.create-issue.outputs.number }} has been created and assigned to you 🫵👁️👄👁️
             
             See it or modify it here: 
               * ${{ steps.create-issue.outputs.url }}

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           filename: .github/external-doc-issue.yml
           assignees: ${{ github.event.pull_request.user.login }}
-          update_existing: false
+          update_existing: true
           search_existing: all
       - name: Create or update a comment
         env:
@@ -52,5 +52,7 @@ jobs:
             
             See it or modify it here: 
               * ${{ steps.create-issue.outputs.url }}
+            
+            _This unique comment uses the very cool [taoliujun/action-unique-comment](https://github.com/marketplace/actions/unique-comment). Thank you <3_
 
       

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -31,6 +31,9 @@ jobs:
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.number }}
+          CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
         uses: JasonEtco/create-an-issue@v2
         with:
           filename: .github/external-doc-issue.yml
@@ -45,7 +48,9 @@ jobs:
         with:
           script: |
             const issue_number = context.payload.pull_request.number;
-            const message = `You updated $CHANGED_FILES. Update the external doc as well by making a PR on either:
+            const message = `You updated ${{ env.CHANGED_FILES }}.
+                
+                Update the external doc as well by making a PR on either:
             
             * [Astro](https://github.com/withastro/docs).
             * More to come ;)?

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -9,7 +9,8 @@ jobs:
   changed_files:
     runs-on: ubuntu-latest
     name: Test changed-files
-    permissions: # Needed to post comments and create issues
+    # Needed to post comments and create issues
+    permissions:
         issues: write
         pull-requests: write
         contents: read

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -1,0 +1,60 @@
+name: Update external doc?
+
+on:
+  pull_request_target:
+    types: [opened, closed, synchronize, reopened]
+    branches: [ main ]
+
+jobs:
+  changed_files:
+    runs-on: ubuntu-latest  # windows-latest || macos-latest
+    name: Test changed-files
+    permissions:
+        issues: write
+        pull-requests: write
+        contents: read
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize' }}
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+      - name: Get files linked to external doc
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            content/guides/astro.md
+      - name: Create issue
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: JasonEtco/create-an-issue@v2
+        with:
+          filename: .github/external-doc-issue.yml
+          assignees: |
+            ${{ github.event.pull_request.user.login }}
+            juliamrch
+      - name: Run step if external doc has changed
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.pull_request.number;
+            const message = `You updated $CHANGED_FILES. Update the external doc as well by making a PR on either:
+            
+            * [Astro](https://github.com/withastro/docs).
+            * More to come ;)?
+            `;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: message
+                });
+      

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -34,9 +34,8 @@ jobs:
         uses: JasonEtco/create-an-issue@v2
         with:
           filename: .github/external-doc-issue.yml
-          assignees: |
-            ${{ github.event.pull_request.user.login }}
-            juliamrch
+          assignees: ${{ github.event.pull_request.user.login }}
+        
       - name: Run step if external doc has changed
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 /public/*
 /resources
 .clever.json

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -23,7 +23,7 @@ draft: false
 
 ## Overview
 
-Clever Cloud supportes deploying both fully static and on-demand rendered Astro projects. Regardless of your `output` mode ([pre-rendered or on-demand](/en/basics/rendering-modes/)), you can choose to deploy as a **static application** which runs using a post-build hook, or as a **Node.js** application, which works out-of-the-box with your `package.json`.
+Clever Cloud supports deploying both fully static and on-demand rendered Astro projects. Regardless of your `output` mode ([pre-rendered or on-demand](/en/basics/rendering-modes/)), you can choose to deploy as a **static application** which runs using a post-build hook, or as a **Node.js** application, which works out-of-the-box with your `package.json`.
 
 If you need an example source code, get [Astrowind](https://github.com/onwidget/astrowind) (you'll need [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Node.js](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs)):
 ```bash
@@ -67,43 +67,25 @@ Applications on Clever Cloud listen on port **8080**. If your project requires t
 
 {{< /tabs >}}
 
-## Deploy Astro from the Console
+## Deploy Astro  from the Console
 
-To deploy your Astro project to Clever Cloud, you will need to **create a new application**. The application wizard will walk you through the necessary configuration steps.
+To deploy your Astro project to Clever Cloud, you **create a new application**. 
 
 {{% steps %}}
 
-### Create the application 
+### Create the application
 
-From the lateral menubar, click **Create** > **An application**
+In this step, you set up the following parameters:
 
-### Choose how to deploy:
+- Deployment (using Git or GitHub)
+- Application : Node.js or Static
+- Instance size and scalability options : Astro sites can typically be deployed using the **Nano** instance
+- Region
+- Dependencies, if needed
 
- - **Create a brand new app**: to deploy from a local repository with Git
+### Inject environment variables
 
-    or
-
- - **Select a GitHub repository**: to deploy from GitHub
-
-### Select the type of application
-
-Select a **Node.js** application, or a **static** one.
-
-### Set up instance minimal size and scalability
-
-Set up the minimal size for your instance and scalability options. Astro sites can typically be deployed using the **Nano** instance. Depending on your project's specifications and dependencies, you may need to adjust accordingly as you watch the metrics from the **Overview** page.
-
-### Select the region
-
-Select a **region** to deploy your instance.
-
-### Connected services
-
-Skip [connecting **Add-ons** to your Clever application](/doc/addons/) unless you're using a database or Keycloak.
-
-### Inject **environment variables**
-
-For **Node.js**, no specific environment variable is needed to deploy Astro if you're using **npm**. If you're using **yarn** or **pnpm**, or deploying on a Static application, set the following environment variables.
+For **Node.js**, no specific environment variable is needed to deploy Astro if you're using **npm**. If you're using **yarn** or **pnpm**, or deploying on a Static application, set the following environment variables:
 
 {{% /steps %}}
 
@@ -168,14 +150,11 @@ For **Node.js**, no specific environment variable is needed to deploy Astro if y
 
   {{< /tab >}}
 
-
 {{< /tabs >}}
 
-### Deploy!
+### Deploy
 
-If you're deploying from **GitHub**, your deployment should start automatically. If you're using **Git**, copy the remote and push on the **master** branch. 
-
-
+If you're deploying from **GitHub**, your deployment should start automatically. If you're using **Git**, copy the remote and push on the **master** branch.
 
 {{< callout emoji="💡" >}}
   To deploy from branches other than `master`, use `git push clever <branch>:master`. For example, if you want to deploy your local `main` branch without renaming it, use `git push clever main:master`.
@@ -187,7 +166,7 @@ If you're deploying from **GitHub**, your deployment should start automatically.
 
 ## Configure environment variables
 
-Next, we configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
+Next, configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. Clever Cloud uses standard configurations, so you only need to define a few variables:
 
 ```bash
 clever scale --build-flavor M
@@ -205,8 +184,8 @@ clever env set CC_POST_BUILD_HOOK "npm run build"
 ## Learn more
 
 {{< cards >}}
-  {{< card link="../doc/applications/javascript/nodejs" title="Deploy a Node.js application" subtitle="Learn more on deploying a Node.js application on Clever Cloud" icon="node" >}}
-  {{< card link="../doc/applications/static" title="Deploy a Static application" subtitle="Learn more on deploying a Static application on Clever Cloud" icon="feather" >}}
+  {{< card link="../../doc/applications/javascript/nodejs" title="Deploy a Node.js application" subtitle="Learn more on deploying a Node.js application on Clever Cloud" icon="node" >}}
+  {{< card link="../../doc/applications/static" title="Deploy a Static application" subtitle="Learn more on deploying a Static application on Clever Cloud" icon="feather" >}}
   {{< card link="https://docs.astro.build/" title="Learn Astro" subtitle="Astro full documentation" icon="rocket-launch" >}}
   
 {{< /cards >}}

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -30,45 +30,7 @@ If you need an example source code, get [Astrowind](https://github.com/onwidget/
 git clone https://github.com/onwidget/astrowind myStaticApp
 ```
 
-## Port and host
-
-Applications on Clever Cloud listen on port **8080**. If your project requires this configuration, set your port and host in Astro in one of two locations:
-
-{{< tabs items="package.json scripts,astro.config.mjs" >}}
-
-  {{< tab >}}
-
-   ```json {filename="package.json"}
-    "scripts": {
-      "dev": "astro dev",
-      "start": "astro dev",
-      "build": "astro check && astro build",
-      "preview": "astro preview --host 0.0.0.0 --port 8080",
-      "astro": "astro"
-    } 
-    ```
-  
-  {{< /tab >}}
-
-  {{< tab >}}
-
-   ```javascript {filename="astro.config.mjs"}
-    import { defineConfig } from 'astro/config';
-
-    export default defineConfig({
-      server: {
-        port: 8080,
-        host: true
-      }
-    });
-    ```
-
-  {{< /tab >}}
-
-
-{{< /tabs >}}
-
-## Deploy Astro  from the Console
+## Deploy a static Astro site
 
 To deploy your Astro project to Clever Cloud, you need to **create a new application**. 
 
@@ -79,21 +41,30 @@ To deploy your Astro project to Clever Cloud, you need to **create a new applica
 In this step, you set up the following parameters:
 
 - Deployment (using Git or GitHub)
-- Application : Node.js or Static
+- Application : Node.js or Static (both can serve a static site)
 - Instance size and scalability options : Astro sites can typically be deployed using the **Nano** instance
 - Region
 - Dependencies, if needed
 
 ### Inject environment variables
 
-For **Node.js**, no specific environment variable is needed to deploy Astro if you're using **npm**. If you're using **yarn** or **pnpm**, or deploying on a Static application, set the following environment variables:
+Environment variables are used to control the deplotment behavior, and depend on the type of application and your package manager. Find right below the ones that apply for your application.
 
 {{% /steps %}}
 
-#### Node.js variables
+#### Node.js application environment variables
 
-{{< tabs items="pnpm,yarn" >}}
-  
+If you're using a **Node.js** application to serve a static Astro site, inject the following environment variables:
+
+{{< tabs items="npm,pnpm,yarn" >}}
+  {{< tab >}}
+
+  ```shell
+    CC_POST_BUILD_HOOK="npm run build"
+    ```
+
+  {{< /tab >}}
+
   {{< tab >}}
 
   ```shell
@@ -108,16 +79,18 @@ For **Node.js**, no specific environment variable is needed to deploy Astro if y
   {{< tab >}}
 
   ```shell
-      CC_NODE_BUILD_TOOL="yarn"
-      CC_PRE_BUILD_HOOK="yarn && yarn run astro telemetry disable && yarn build"
-      CC_RUN_COMMAND="yarn run preview"
+    CC_NODE_BUILD_TOOL="yarn"
+    CC_PRE_BUILD_HOOK="yarn && yarn run astro telemetry disable && yarn build"
+    CC_RUN_COMMAND="yarn run preview"
     ```
 
   {{< /tab >}}
 
 {{< /tabs >}}
 
-#### Static application variables
+#### Static application
+
+If you're using a **Static** application to serve a static Astro site, inject the following environment variables:
 
 {{< tabs items="npm,pnpm,yarn" >}}
   
@@ -161,14 +134,7 @@ If you're deploying from **GitHub**, your deployment should start automatically.
   To deploy from branches other than `master`, use `git push clever <branch>:master`. For example, if you want to deploy your local `main` branch without renaming it, use `git push clever main:master`.
 {{< /callout >}}
 
-### Serve the site from server
-
-If the app uses the [Node.js adapter](https://docs.astro.build/en/guides/integrations-guide/node/), it can start by either:
-
-- Injecting `CC_RUN_COMMAND=./dist/server/entry.mjs` in environment variables. `CC_RUN_COMMAND` variable always overrides start script in `package.json`.
-- Setting `./dist/server/entry.mjs` as start script in `package.json`. 
-
-## Deploy an Astro site using the CLI
+## Deploy a static Astro site using the CLI
 
 {{% content/language-specific-deploy/create-static %}}
 
@@ -188,6 +154,66 @@ clever env set CC_POST_BUILD_HOOK "npm run build"
 ```
 
 {{% content/git-push %}}
+
+## Deploying an Astro Project with Server-Side Rendering (SSR)
+
+To deploy an Astro SSR project, consider using a **Node.js** application on Clever Cloud. This is especially useful if your project uses the [Node.js adapter](https://docs.astro.build/en/guides/integrations-guide/node/).
+
+### Port and host
+
+For SSR deployments, ensure to configure your application to listen on port **8080** as required by Clever Cloud. This differs from static deployments where such configurations are typically unnecessary.
+
+Set your port and host in your `astro dev` script for development mode, and/or configure it directly for production:
+
+{{< tabs items="dev,production" >}}
+
+  {{< tab >}}
+
+  To quickly deploy on dev mode:
+
+   ```json {filename="package.json"}
+    "scripts": {
+      "dev": "astro dev",
+      "start": "astro dev",
+      "build": "astro check && astro build",
+      "preview": "astro preview --host 0.0.0.0 --port 8080",
+      "astro": "astro"
+    } 
+    ```
+  
+  {{< /tab >}}
+
+  {{< tab >}}
+
+  When deploying for production:
+
+   ```javascript {filename="astro.config.mjs"}
+    import { defineConfig } from 'astro/config';
+
+    export default defineConfig({
+      server: {
+        port: 8080,
+        host: true
+      }
+    });
+    ```
+  ```json {filename="package.json"}
+    "scripts": {
+      "dev": "astro dev",
+      "start": "astro build && node ./dist/server/entry.mjs",
+      "build": "astro check && astro build",
+      "preview": "astro preview --host 0.0.0.0 --port 8080",
+      "astro": "astro"
+    } 
+    ```
+
+  {{< /tab >}}
+
+
+{{< /tabs >}}
+
+### Deploying for production
+
 
 ## Learn more
 

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -207,6 +207,6 @@ clever env set CC_POST_BUILD_HOOK "npm run build"
 {{< cards >}}
   {{< card link="../doc/applications/javascript/nodejs" title="Deploy a Node.js application" subtitle="Learn more on deploying a Node.js application on Clever Cloud" icon="node" >}}
   {{< card link="../doc/applications/static" title="Deploy a Static application" subtitle="Learn more on deploying a Static application on Clever Cloud" icon="feather" >}}
-  {{< card link="https://docs.astro.build/en/getting-started/" title="Learn Astro" subtitle="Astro full documentation" icon="rocket-launch" >}}
+  {{< card link="https://docs.astro.build/" title="Learn Astro" subtitle="Astro full documentation" icon="rocket-launch" >}}
   
 {{< /cards >}}

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -212,7 +212,6 @@ Set your port and host in your `astro dev` script for development mode, and/or c
 
 {{< /tabs >}}
 
-### Deploying for production
 
 
 ## Learn more

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -17,10 +17,171 @@ comments: false
 draft: false
 ---
 
+{{< hextra/hero-subtitle >}}
+  Astro is an all-in-one web framework for building content-driven websites, that pioneers a new frontend architecture to reduce JavaScript overhead and complexity. Learn in this guide how to deploy an Astro site on Clever Cloud.
+{{< /hextra/hero-subtitle >}}
+
+## Overview
+
+Clever Cloud supportes deploying both fully static and on-demand rendered Astro projects. Regardless of your `output` mode ([pre-rendered or on-demand](/en/basics/rendering-modes/)), you can choose to deploy as a **static application** which runs using a post-build hook, or as a **Node.js** application, which works out-of-the-box with your `package.json`.
+
 If you need an example source code, get [Astrowind](https://github.com/onwidget/astrowind) (you'll need [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Node.js](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs)):
 ```bash
 git clone https://github.com/onwidget/astrowind myStaticApp
 ```
+
+## Port and host
+
+Applications on Clever Cloud listen on port **8080**. If your project requires this configuration, set your port and host in Astro in one of two locations:
+
+{{< tabs items="package.json scripts,astro.config.mjs" >}}
+
+  {{< tab >}}
+
+   ```json {filename="package.json"}
+    "scripts": {
+      "dev": "astro dev",
+      "start": "astro dev",
+      "build": "astro check && astro build",
+      "preview": "astro preview --host 0.0.0.0 --port 8080",
+      "astro": "astro"
+    } 
+    ```
+  {{< /tab >}}
+
+  {{< tab >}}
+
+   ```javascript {filename="astro.config.mjs"}
+    import { defineConfig } from 'astro/config';
+
+    export default defineConfig({
+      server: {
+        port: 8080,
+        host: true
+      }
+    });
+    ```
+
+  {{< /tab >}}
+
+
+{{< /tabs >}}
+
+## Deploy Astro from the Console
+
+To deploy your Astro project to Clever Cloud, you will need to **create a new application**. The application wizard will walk you through the necessary configuration steps.
+
+{{% steps %}}
+
+### Create the application 
+
+From the lateral menubar, click **Create** > **An application**
+
+### Choose how to deploy:
+
+ - **Create a brand new app**: to deploy from a local repository with Git
+
+    or
+
+ - **Select a GitHub repository**: to deploy from GitHub
+
+### Select the type of application
+
+Select a **Node.js** application, or a **static** one.
+
+### Set up instance minimal size and scalability
+
+Set up the minimal size for your instance and scalability options. Astro sites can typically be deployed using the **Nano** instance. Depending on your project's specifications and dependencies, you may need to adjust accordingly as you watch the metrics from the **Overview** page.
+
+### Select the region
+
+Select a **region** to deploy your instance.
+
+### Connected services
+
+Skip [connecting **Add-ons** to your Clever application](/doc/addons/) unless you're using a database or Keycloak.
+
+### Inject **environment variables**
+
+For **Node.js**, no specific environment variable is needed to deploy Astro if you're using **npm**. If you're using **yarn** or **pnpm**, or deploying on a Static application, set the following environment variables.
+
+{{% /steps %}}
+
+#### Node.js variables
+
+{{< tabs items="pnpm,yarn" >}}
+  
+  {{< tab >}}
+
+  ```shell
+    CC_NODE_BUILD_TOOL="custom"
+    CC_PRE_BUILD_HOOK="npm install -g pnpm && pnpm install"
+    CC_CUSTOM_BUILD_TOOL="pnpm run astro telemetry disable && pnpm build"
+    CC_RUN_COMMAND="pnpm run preview"
+    ```
+
+  {{< /tab >}}
+
+  {{< tab >}}
+
+  ```shell
+      CC_NODE_BUILD_TOOL="yarn"
+      CC_PRE_BUILD_HOOK="yarn && yarn run astro telemetry disable && yarn build"
+      CC_RUN_COMMAND="yarn run preview"
+    ```
+
+  {{< /tab >}}
+
+{{< /tabs >}}
+
+#### Static application variables
+
+{{< tabs items="npm,pnpm,yarn" >}}
+  
+  {{< tab >}}
+
+  ```shell
+    CC_POST_BUILD_HOOK="npm run build"
+    CC_PRE_BUILD_HOOK="npm install && npm run astro telemetry disable"
+    CC_WEBROOT="/dist"
+  ```
+
+  {{< /tab >}}
+
+  {{< tab >}}
+
+  ```shell
+    CC_POST_BUILD_HOOK="pnpm build"
+    CC_PRE_BUILD_HOOK="npm install -g pnpm && pnpm install && pnpm run astro telemetry disable"
+    CC_WEBROOT="/dist"
+  ```
+
+  {{< /tab >}}
+
+  {{< tab >}}
+
+  ```shell
+    CC_POST_BUILD_HOOK="yarn build"
+    CC_PRE_BUILD_HOOK="yarn && yarn run astro telemetry disable"
+    CC_WEBROOT="/dist"
+  ```
+
+  {{< /tab >}}
+
+
+{{< /tabs >}}
+
+### Deploy!
+
+If you're deploying from **GitHub**, your deployment should start automatically. If you're using **Git**, copy the remote and push on the **master** branch. 
+
+
+
+{{< callout emoji="💡" >}}
+  To deploy from branches other than `master`, use `git push clever <branch>:master`. For example, if you want to deploy your local `main` branch without renaming it, use `git push clever main:master`.
+{{< /callout >}}
+
+## Deploy an Astro site using the CLI
 
 {{% content/language-specific-deploy/create-static %}}
 
@@ -40,3 +201,12 @@ clever env set CC_POST_BUILD_HOOK "npm run build"
 ```
 
 {{% content/git-push %}}
+
+## Learn more
+
+{{< cards >}}
+  {{< card link="../doc/applications/javascript/nodejs" title="Deploy a Node.js application" subtitle="Learn more on deploying a Node.js application on Clever Cloud" icon="node" >}}
+  {{< card link="../doc/applications/static" title="Deploy a Static application" subtitle="Learn more on deploying a Static application on Clever Cloud" icon="feather" >}}
+  {{< card link="https://docs.astro.build/en/getting-started/" title="Learn Astro" subtitle="Astro full documentation" icon="rocket-launch" >}}
+  
+{{< /cards >}}

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -47,6 +47,7 @@ Applications on Clever Cloud listen on port **8080**. If your project requires t
       "astro": "astro"
     } 
     ```
+  
   {{< /tab >}}
 
   {{< tab >}}
@@ -159,6 +160,13 @@ If you're deploying from **GitHub**, your deployment should start automatically.
 {{< callout emoji="💡" >}}
   To deploy from branches other than `master`, use `git push clever <branch>:master`. For example, if you want to deploy your local `main` branch without renaming it, use `git push clever main:master`.
 {{< /callout >}}
+
+### Serve the site from server
+
+If the app uses the [Node.js adapter](https://docs.astro.build/en/guides/integrations-guide/node/), it can start by either:
+
+- Injecting `CC_RUN_COMMAND=./dist/server/entry.mjs` in environment variables. `CC_RUN_COMMAND` variable always overrides start script in `package.json`.
+- Setting `./dist/server/entry.mjs` as start script in `package.json`. 
 
 ## Deploy an Astro site using the CLI
 

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -48,7 +48,7 @@ In this step, you set up the following parameters:
 
 ### Inject environment variables
 
-Environment variables are used to control the deplotment behavior, and depend on the type of application and your package manager. Find right below the ones that apply for your application.
+Environment variables are used to control the deployment behavior, and depend on the type of application and your package manager. Find right below the ones that apply for your application.
 
 {{% /steps %}}
 

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -42,13 +42,13 @@ In this step, you set up the following parameters:
 
 - Deployment (using Git or GitHub)
 - Application : Node.js or Static (both can serve a static site)
-- Instance size and scalability options : Astro sites can typically be deployed using the **Nano** instance
+- Instance size and scalability options : You can usually deploy an Astro site using the **Nano** instance
 - Region
 - Dependencies, if needed
 
 ### Inject environment variables
 
-Environment variables are used to control the deployment behavior, and depend on the type of application and your package manager. Find right below the ones that apply for your application.
+Use environment variables to control the deployment behavior, which depends on the type of application and your package manager. Find right below the ones that apply for your application.
 
 {{% /steps %}}
 
@@ -165,11 +165,11 @@ For SSR deployments, ensure to configure your application to listen on port **80
 
 Set your port and host in your `astro dev` script for development mode, and/or configure it directly for production:
 
-{{< tabs items="dev,production" >}}
+{{< tabs items="development,production" >}}
 
   {{< tab >}}
 
-  To quickly deploy on dev mode:
+  To quickly deploy on development mode:
 
    ```json {filename="package.json"}
     "scripts": {

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -70,7 +70,7 @@ Applications on Clever Cloud listen on port **8080**. If your project requires t
 
 ## Deploy Astro  from the Console
 
-To deploy your Astro project to Clever Cloud, you **create a new application**. 
+To deploy your Astro project to Clever Cloud, you need to **create a new application**. 
 
 {{% steps %}}
 

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -23,7 +23,9 @@ draft: false
 
 ## Overview
 
-Clever Cloud supports deploying both fully static and on-demand rendered Astro projects. Regardless of your `output` mode ([pre-rendered or on-demand](/en/basics/rendering-modes/)), you can choose to deploy as a **static application** which runs using a post-build hook, or as a **Node.js** application, which works out-of-the-box with your `package.json`.
+Clever Cloud supports deploying both [fully static and on-demand rendered](https://docs.astro.build/en/basics/rendering-modes/) Astro projects:
+- The `static` output mode is ideal for most content-oriented website, for which you have no need for per-visitor server-side customisation. Consider using a [Static runtime](/doc/applications/static/) when using this output mode, with the site generation in a post-build hook.
+-  The `server` or `hybrid` output modes: consider using a [Node.js runtime](/doc/applications/javascript/nodejs/) runtime with [Astro’s Node adapter](https://docs.astro.build/en/guides/integrations-guide/node/)
 
 If you need an example source code, get [Astrowind](https://github.com/onwidget/astrowind) (you'll need [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Node.js](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs)):
 ```bash


### PR DESCRIPTION
## Describe your PR

A Clever Cloud guide has been included on Astro, and therefore we updated as well our guide to include detailed configuration depending on whether it's deployed on a static or a node application.

In order to avoid asynchronicity between our development and the external doc posted on diverse frameworks, I wrote an automation to check if the modified files are linked to some external doc. If relevant, the bot creates an issue and assign it to the PR author, as well as notifying this on a comment.  

- [Updated Astro guide](http://documentation-pr-388.cleverapps.io/guides/astro/)
-  [Demo: Issue created](https://github.com/juliamrch/cc-doc-tests/issues/30)
- [Demo: Comment on PR](https://github.com/juliamrch/cc-doc-tests/pull/29#issuecomment-2387222892)


## Checklist

- [x] My PR is related to an opened issue : #383
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @cnivolle 

