### PR TITLE
add-ons: shorten dev plan message

### DIFF
--- a/layouts/shortcodes/software_versions_shared_dedicated.html
+++ b/layouts/shortcodes/software_versions_shared_dedicated.html
@@ -33,6 +33,6 @@
   </tbody>
 </table>
 {{ if $has_dev }}
-  {{ $.Page.RenderString "<!-- markdown -->{{< callout type=\"warning\">}}  <strong>Important</strong>: Dev plans are free and intended <u>solely for testing purposes</u>. They don't provide the same guarantees or SLAs as dedicated plans. {{< /callout >}}" | safeHTML }}
+  {{ $.Page.RenderString "<!-- markdown -->{{< callout type=\"warning\">}}  <strong>Important</strong>: Dev plans are free and <u>solely for testing purposes</u>. They don't provide the same guarantees or SLAs as dedicated plans. {{< /callout >}}" | safeHTML }}
 {{ end }}
 


### PR DESCRIPTION
## Describe your PR

The Dev Plan callout is on 2-lines for an only word. I've shortened it to appear on 1 line, removing a superfluous word. 