### PR TITLE
Add new environnment variable to reference

### DIFF
--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -238,7 +238,9 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 |`CC_REALPATH_CACHE_TTL` | The size of the realpath cache to be used by PHP | 120 |
 |`CC_WEBROOT` | Define the `DocumentRoot` of your project | `.` |
 |`ENABLE_ELASTIC_APM_AGENT` | Elastic APM Agent for PHP | `true` if `ELASTIC_APM_SERVER_URL` is defined, `false` otherwise |
+|`ENABLE_GRPC` | Enable the use of gRPC module | false |
 |`ENABLE_REDIS` |  | false |
+|`ENABLE_PDFLIB` | Enable the use of PDFlib module | false |
 |`HTTP_TIMEOUT` | Define a custom HTTP timeout | 180 |
 |`LDAPTLS_CACERT` |  |  |
 |`MAX_INPUT_VARS` |  |  |

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -239,8 +239,8 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 |`CC_WEBROOT` | Define the `DocumentRoot` of your project | `.` |
 |`ENABLE_ELASTIC_APM_AGENT` | Elastic APM Agent for PHP | `true` if `ELASTIC_APM_SERVER_URL` is defined, `false` otherwise |
 |`ENABLE_GRPC` | Enable the use of gRPC module | false |
-|`ENABLE_REDIS` |  | false |
 |`ENABLE_PDFLIB` | Enable the use of PDFlib module | false |
+|`ENABLE_REDIS` |  | false |
 |`HTTP_TIMEOUT` | Define a custom HTTP timeout | 180 |
 |`LDAPTLS_CACERT` |  |  |
 |`MAX_INPUT_VARS` |  |  |


### PR DESCRIPTION
## Describe your PR

To use PDFlib or gRPC on a PHP app, you need to use the env var ENABLE_PDFLIB and ENABLE_GRPC.
Currently, they weren't present in the documentation, so i added them to the reference of environnement variables.


## Checklist

- [x] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @

