### PR TITLE
Add warning MongoDB dev plan is disabled

### DIFF
--- a/content/doc/addons/mongodb/_index.md
+++ b/content/doc/addons/mongodb/_index.md
@@ -36,6 +36,10 @@ If you puchased a higher version from MongoDB and you want to deploy your databa
 
 Free plans are recommended for test and development usage only. Using these databases in production is not recommended, because performance may vary depending on the global usage of the cluster. Therefore, before switching to production, consider upgrading to a dedicated database for better performance.
 
+{{< callout type="warning" >}}
+The ability to create free plan for MongoDB is currently turned off. It may come back in the future.
+{{< /callout >}}
+
 ### Important Note About Fair Use on Free Databases
 
 Heavy usage of free databases may impact the shared cluster they rely upon. It will degrade performance of the other databases. To that extent, we set a soft limit of **15 operations/second**. Going above the limit will expose your database to disconnection, would you not answer our notices.


### PR DESCRIPTION
## Describe your PR

You currently can't create a mongoDB dev plan.
I added a warning that creating such plan is currently impossible in the documentation.

## Checklist

- [x] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @

