### PR TITLE
Missing haskell variables

### DIFF
--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -174,6 +174,9 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 |  Name  |  Description  |
 |-----------------------|------------------------------|
 |[`CC_HASKELL_STACK_TARGET`](/doc/applications/haskell/#specify-stack-package-target "Specify Stack package target") | Specify Stack package target. |
+|`CC_HASKELL_STACK_SETUP_COMMAND` | Only use this variable to override the default `SETUP` step when running Haskell |
+|`CC_HASKELL_STACK_INSTALL_COMMAND` | Only use this variable to override the default `INSTALL` step when running Haskell |
+|`CC_HASKELL_STACK_INSTALL_DEPENDENCIES_COMMAND` | Only use this variable to override the `INSTALL DEPENDENCIES` one when running Haskell |
 |`CC_RUN_COMMAND` | Custom command to run your application. |
 
 ## Java

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -174,9 +174,9 @@ If `TAILSCALE_LOGIN_SERVER` is provided, the agent will be configured to reach a
 |  Name  |  Description  |
 |-----------------------|------------------------------|
 |[`CC_HASKELL_STACK_TARGET`](/doc/applications/haskell/#specify-stack-package-target "Specify Stack package target") | Specify Stack package target. |
-|`CC_HASKELL_STACK_SETUP_COMMAND` | Only use this variable to override the default `SETUP` step when running Haskell |
-|`CC_HASKELL_STACK_INSTALL_COMMAND` | Only use this variable to override the default `INSTALL` step when running Haskell |
-|`CC_HASKELL_STACK_INSTALL_DEPENDENCIES_COMMAND` | Only use this variable to override the `INSTALL DEPENDENCIES` one when running Haskell |
+|`CC_HASKELL_STACK_SETUP_COMMAND` | Only use this variable to override the default `setup` Stack step command |
+|`CC_HASKELL_STACK_INSTALL_COMMAND` | Only use this variable to override the default `install` Stack step command |
+|`CC_HASKELL_STACK_INSTALL_DEPENDENCIES_COMMAND` | Only use this variable to override the default `install --only-dependencies` Stack step command |
 |`CC_RUN_COMMAND` | Custom command to run your application. |
 
 ## Java


### PR DESCRIPTION
## Describe your PR
3 variables where missing:
`CC_HASKELL_STACK_SETUP_COMMAND` 
`CC_HASKELL_STACK_INSTALL_COMMAND`
`CC_HASKELL_STACK_INSTALL_DEPENDENCIES_COMMAND`

To be used if the default steps from running Haskell aren't enough for the customer:
https://developers.clever-cloud.com/doc/applications/haskell/#mandatory-configuration


## Checklist

- [x] My PR is related to an opened issue : #38
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
@CleverCloud/reviewers 

