### PR TITLE
Display custom backup error

### DIFF
--- a/content/doc/find-help/faq.md
+++ b/content/doc/find-help/faq.md
@@ -210,3 +210,6 @@ If a VACUUM operation needs more disk that there is remaining, migrating to the 
 Clever Cloud store all your backups on [Cellar](https://www.clever-cloud.com/product/cellar-object-storage/). 
 Cellar has a replication system to protect the data stored inside. It creates three copies of your backups, each stored in a different datacenters in the PAR region.  
 This way, even if one datacenter has an accident, your backup are still safe in two different datacenters.
+
+If you have a custom backup configuration with multiple retention policies and periods, the Clever Cloud console will not display all the available backups for restoration. 
+However, you can restore a specific backup using the CLI. This allows for greater flexibility in managing and restoring backups outside the standard console interface.


### PR DESCRIPTION
## Describe your PR

This PR updates the backup documentation to clarify the behavior of custom backup configurations with multiple retention policies and periods. It explains that while the Clever Cloud console does not display all backups for restoration, users can leverage the CLI to restore a specific backup.



