### PR TITLE
Add header injection in PHP with .htaccess

### DIFF
--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -112,6 +112,11 @@ To inject headers on HTTP responses, add this configuration to `.htaccess` file:
 
 ```sh
 Header set Access-Control-Allow-Origin "*"
+```
+
+{{< callout type="info" >}}
+You can use a .htaccess file to create or update headers, but you not delete them.
+{{< /callout >}}
 
 ###### With PHP
 

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -106,18 +106,26 @@ date.timezone=Europe/Paris
 
 ##### Header injection
 
-Usually, you can use an `.htaccess` file to create / update / delete headers.
-You won't be able to do it from the `.htaccess` file if the headers come from a `.php` file, because `php-fpm` ignores the `mod_headers` plugin.
-It works fine for static files directly served by apache.
+###### With .htaccess
 
-So if you need to inject headers on HTTP responses (for instance for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)),
-you have to do it from PHP (you can't do it from `.htaccess`).
+You can use a `.htaccess` file to create or update headers, but you can't delete them.
+
+If you need to inject headers on HTTP responses (for instance for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)),
+you can do it like this :
+
+```sh
+Header set Access-Control-Allow-Origin "*"
+```
+
+###### With PHP
+
+You can also do it from PHP.
 
 ```php
 header("Access-Control-Allow-Origin: *");
 ```
 
-If you want to keep this separate from your application, you can configure the application to execute some code on every request.
+f you want to keep this separate from your application, you can configure the application to execute some code on every request.
 
 In `.user.ini`, add the following line (you need to create `inject_headers.php` first):
 

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -111,7 +111,8 @@ date.timezone=Europe/Paris
 To inject headers on HTTP responses, add this configuration to `.htaccess` file:
 
 ```sh
-Header set Access-Control-Allow-Origin "*"
+Header Set Access-Control-Allow-Origin "https://www.example.com"
+Header Set Access-Control-Allow-Headers "Authorization"
 ```
 
 {{< callout type="info" >}}
@@ -123,7 +124,8 @@ You can use a `.htaccess` file to create or update headers, but you can't delete
 You can also do it from PHP:
 
 ```php
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.example.com");
+header("Access-Control-Allow-Headers: Authorization");
 ```
 
 If you want to keep this separate from your application, you can configure the application to execute some code on every request.

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -119,7 +119,7 @@ Header set Access-Control-Allow-Origin "*"
 
 ###### With PHP
 
-You can also do it from PHP.
+You can also do it from PHP:
 
 ```php
 header("Access-Control-Allow-Origin: *");

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -125,7 +125,7 @@ You can also do it from PHP.
 header("Access-Control-Allow-Origin: *");
 ```
 
-f you want to keep this separate from your application, you can configure the application to execute some code on every request.
+If you want to keep this separate from your application, you can configure the application to execute some code on every request.
 
 In `.user.ini`, add the following line (you need to create `inject_headers.php` first):
 

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -115,7 +115,7 @@ Header set Access-Control-Allow-Origin "*"
 ```
 
 {{< callout type="info" >}}
-You can use a .htaccess file to create or update headers, but you can't delete them.
+You can use a `.htaccess` file to create or update headers, but you can't delete them.
 {{< /callout >}}
 
 ###### With PHP

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -108,14 +108,10 @@ date.timezone=Europe/Paris
 
 ###### With .htaccess
 
-You can use a `.htaccess` file to create or update headers, but you can't delete them.
-
-If you need to inject headers on HTTP responses (for instance for [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)),
-you can do it like this :
+To inject headers on HTTP responses, add this configuration to `.htaccess` file:
 
 ```sh
 Header set Access-Control-Allow-Origin "*"
-```
 
 ###### With PHP
 

--- a/content/doc/applications/php/_index.md
+++ b/content/doc/applications/php/_index.md
@@ -115,7 +115,7 @@ Header set Access-Control-Allow-Origin "*"
 ```
 
 {{< callout type="info" >}}
-You can use a .htaccess file to create or update headers, but you not delete them.
+You can use a .htaccess file to create or update headers, but you can't delete them.
 {{< /callout >}}
 
 ###### With PHP


### PR DESCRIPTION
## Describe your PR

Currently, the documentation say that it is impossible to do header injection in PHP with a.htaccess file because php-fpm ignores the mod_headers plugin.

This is not true anymore as php-fpm doesn't ignore mod_headers anymore. You can now set or update headers with .htaccess.  
I modified the documentation to show how to use inject header with .htaccess and also kept the method using PHP.

## Checklist

- [x] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @

