### PR TITLE
vale: add a suggestion rule for hyphenated words

### DIFF
--- a/.github/styles/Clever/hyphens.yml
+++ b/.github/styles/Clever/hyphens.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Write '%s' with hyphens when used as an adjective before a noun, but as separate words when it appears as a noun phrase or after a verb"
+level: suggestion
+ignorecase: true
+tokens:
+  - 'up-to-date'
+  - 'up to date'
+  - 'end-of-life'
+  - 'end of life'

--- a/.vale.ini
+++ b/.vale.ini
@@ -7,7 +7,7 @@ MinAlertLevel = suggestion
 Packages = Hugo, Google
 
 [*.md]
-BasedOnStyles = Vale, Google, Guides
+BasedOnStyles = Clever, Vale, Google, Guides
 Google.Headings = NO
 Vale.Terms = NO
 Google.Parens = NO


### PR DESCRIPTION
## Describe your PR

Following discussions on words with an (un)hypenated form, as both are valid, more or less depending on context, I've created a Clever ruleset for Vale with a suggestion rule for such words. `end-of-life` and `up-to-date` are the first concerned here, but we can improve the rule  as we come up with new ideas