### PR TITLE
vale: add e-mail, plug-in to reject list

### DIFF
--- a/.github/styles/config/vocabularies/Doc/reject.txt
+++ b/.github/styles/config/vocabularies/Doc/reject.txt
@@ -1,2 +1,6 @@
 addon
 addons
+plug-in
+plug-ins
+e-mail
+e-mails


### PR DESCRIPTION
## Describe your PR

This PR adds `e-mail(s)` and `plug-in(s)` to reject list. I've based this on doc history and rules in other projects such as Console.