### PR TITLE
fix: Changelog feed URL after page 1

### DIFF
--- a/content/changelog/_index.md
+++ b/content/changelog/_index.md
@@ -6,7 +6,7 @@ description: Additions and changes to the Clever Cloud platform.
 
 Additions and changes to the Clever Cloud platform.  
 
-{{< hextra/hero-badge link="index.xml" style="margin:10px 0 0 0">}}
+{{< hextra/hero-badge link="/changelog/index.xml" style="margin:10px 0 0 0">}}
   Feed
   {{< icon name="rss" attributes="height=14" >}}
 {{< /hextra/hero-badge >}}


### PR DESCRIPTION
## Describe your PR

Fixing the URL of the RSS feed after the page 1.


