### PR TITLE
fix: upgrade hugo version, theme and fix 404 on image

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -31,9 +31,9 @@ jobs:
           ORGA_ID: ${{ secrets.ORGA_ID }}
           GH_CC_PRE_BUILD_HOOK: './clevercloud-deploy-script.sh'
           GH_CC_WEBROOT: '/public'
-          GH_HEXTRA_VERSION: 'v0.8.4'
+          GH_HEXTRA_VERSION: 'v0.9.0'
           GH_HUGO_ENV: 'production'
-          GH_HUGO_VERSION: '0.135.0'
+          GH_HUGO_VERSION: '0.139.5'
 
         with:
           type: 'static-apache'

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -33,7 +33,7 @@ jobs:
           GH_CC_WEBROOT: '/public'
           GH_HEXTRA_VERSION: 'v0.9.0'
           GH_HUGO_ENV: 'production'
-          GH_HUGO_VERSION: '0.139.5'
+          GH_HUGO_VERSION: '0.140.0'
 
         with:
           type: 'static-apache'

--- a/content/doc/quickstart/_index.md
+++ b/content/doc/quickstart/_index.md
@@ -333,7 +333,7 @@ Once an add-on is created, at least two tabs are available in the Clever Cloud c
 
 * **Add-on dashboard:** This screen provides and overview of your add-on and its options, depending on the type of add-on it is.
 
-{{< image "/images/addon-dashboard.png" "Example of the dashoard tab of an add-on" >}}
+{{< image "/developers/images/addon-dashboard.png" "Example of the dashoard tab of an add-on" >}}
 
 * **Information tab:** This screen sums-up the characteristics of the selected add-on.
 Features and environment variables (if applicable) are shown.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/CleverCloud/documentation
 
 go 1.21
 
-require github.com/imfing/hextra v0.8.4 // indirect
+require github.com/imfing/hextra v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/imfing/hextra v0.8.4 h1:cR4asr0TeDlqHPHLdTpMQJOjVeXnq8nfLMzcF0pld+w=
 github.com/imfing/hextra v0.8.4/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.9.0 h1:1UyLZgS1eayce2ETCOjAQssXpkRz3HDrIs/fljH0lkU=
+github.com/imfing/hextra v0.9.0/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -14,7 +14,7 @@ module:
   hugoVersion:
     extended: true
     min: "0.133.0"
-    max: "0.135.0"
+    max: "0.139.5"
 
 outputs:
   home: [HTML]

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -13,7 +13,7 @@ module:
   hugoVersion:
     extended: true
     min: "0.133.0"
-    max: "0.139.5"
+    max: "0.140.0"
 
 outputs:
   home: [HTML, LLMS]


### PR DESCRIPTION
## Describe your PR

Maintenance PR for the site: 

- Upgrade to Hugo [0.140.0]
- Upgrade to [Hextra v0.9.0](https://github.com/imfing/hextra/releases/tag/v0.9.0) (new callouts available)
- fix: 404 on an image 

I injected the environment variables versions to the review app already.

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

