### PR TITLE
fix: arrow for link in code tags

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -234,9 +234,15 @@ html[class~="dark"] .content a:has(code){
 /* Display an arrow at the end of the linked variable */
 .content a:not(.code-block code) code::after {
   content: "\00a0↗";
-  color: tomato;
-  font-size: 1.1rem;
-
+    color: tomato;
+    font-size: 1rem;
+    bottom: -2px;
+    position: relative;
+    left: 4px;
+    width: 14px;
+    display: inline-block;
+    height: 14px;
+    line-height: 0.35em;
 }
 
 /* Display arrow for external links in the main menu.


### PR DESCRIPTION
## Describe your PR

Fix the red arrow for external link in code tags. Especially inside the page "En Var References".

## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers


