### PR TITLE
Fix link in the index page of the CLI section

### DIFF
--- a/content/doc/CLI/_index.md
+++ b/content/doc/CLI/_index.md
@@ -27,7 +27,7 @@ In addition to the Clever Cloud console, you can manage your add-ons and applica
   {{< card link="getting_started" title="Install" icon="arrow-down-tray" >}}
   {{< card link="create" title="Create an application or an add-on" icon="command-line" >}}
   {{< card link="configure" title="Configure an application" icon= "adjustments-horizontal">}}
-  {{< card link="configure" title="Manage an application" icon="wrench-screwdriver" >}}
+  {{< card link="manage" title="Manage an application" icon="wrench-screwdriver" >}}
   {{< card link="lifecycle" title="Manage an application's lifecycle" icon="arrow-path" >}}
   {{< card link="notifications" title="Set notifications" icon="bell" >}}
   {{< card link="ssh-access" title="SSH access an application" icon="key" >}}


### PR DESCRIPTION
## Describe your PR

The "Manage an application" button was wrongly redirecting to the "Configure" page instead of the "Manage" one. So, I just updated the link.


## Checklist

- [x] My PR is not related to any opened issue, I just opened it because I was reading the doc and spotted the issue
- [X] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

