### PR TITLE
chore: delete robots.txt

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -5,7 +5,6 @@ publishDir: public/developers
 pagination:
   pagerSize: 21 # Number of entries in Changelog section before pagination
 
-enableRobotsTXT: true
 enableGitInfo: true
 
 module:

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /
-
-Sitemap: {{ site.Home.Sitemap.Filename | absURL }}


### PR DESCRIPTION
As the domain is now back to clever-cloud.com, there is no need for a dedicated robots.txt for the documentation
