### PR TITLE
Add llms.txt support

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -10,6 +10,7 @@ aliases:
 - /doc/deploy/application/docker/tutorials
 type: "docs"
 comments: false
+llmsTxtOptional: true
 ---
 ## Frameworks
 

--- a/data/software_versions_shared_dedicated.yml
+++ b/data/software_versions_shared_dedicated.yml
@@ -35,3 +35,5 @@ elasticsearch:
 redis:
   dedicated:
     - "v7.2.4"
+
+dev_message: "**Important**: Dev plans are free and **solely for testing purposes**. They don't provide the same guarantees or SLAs as dedicated plans."

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -17,9 +17,18 @@ module:
     max: "0.135.0"
 
 outputs:
-  home: [HTML]
-  page: [HTML]
-  section: [HTML, RSS]
+  home: [HTML, LLMS]
+  page: [HTML, Markdown]
+  section: [HTML, Markdown, RSS]
+
+outputFormats:
+  LLMS:
+    mediaType: "text/plain"
+    baseName: "llms"
+    isPlainText: true
+
+  Markdown:
+    baseName: index.html
 
 privacy:
   youtube:
@@ -37,6 +46,7 @@ languages:
     #title: "Documentation de Clever Cloud "
 
 params:
+  description: Clever Cloud is a Platform-as-a-Service (PaaS) cloud provider, an automated hosting platform for developers. Deploy your app easily and launch dependencies without having to worry about the infrastructure set up
   images:
   - /images/feature.png
   navbar:

--- a/layouts/_default/list.md
+++ b/layouts/_default/list.md
@@ -1,0 +1,1 @@
+{{ partial "markdown/include_entrypoint.md" .RawContent | htmlUnescape }}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,0 +1,1 @@
+{{ partial "markdown/include_entrypoint.md" .RawContent | htmlUnescape }}

--- a/layouts/hextra-home.llms.txt
+++ b/layouts/hextra-home.llms.txt
@@ -1,0 +1,52 @@
+{{- if eq .Kind "home" -}}
+# {{ .Site.Title }}
+
+> {{ .Site.Params.description }}
+
+{{- $mainSections := where .Site.Sections "Type" "docs" -}}
+{{- $sortedSections := sort $mainSections "Title" }}
+{{- range $sortedSections }}
+{{- if and (not .Params.llmsTxtOptional) (gt (len .Pages) 0) }}
+{{- $allSections := slice . -}}
+{{- range .Sections -}}
+{{- if not .Params.llmsTxtOptional -}}
+{{- $allSections = $allSections | append . -}}
+{{- end -}}
+{{- end -}}
+{{- $sortedAllSections := sort $allSections "Title" -}}
+{{- range $sortedAllSections }}
+
+{{- if (gt (len .Pages) 0) }}
+
+## {{ .Title }}
+{{- $pages := sort .Pages "Title" "asc" }}
+{{- range $pages }}
+{{- if not (strings.Contains .RelPermalink "/api/v2") }}
+- [{{ .Title }}]({{ .RelPermalink }}index.html.md){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+## Optional
+{{- range $mainSections }}
+{{- if .Params.llmsTxtOptional }}
+{{- $pages := sort .Pages "Title" "asc" }}
+{{- range $pages }}
+- [{{ .Title }}]({{ .RelPermalink }}index.html.md){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+{{- end }}
+{{- range .Sections }}
+{{- if .Params.llmsTxtOptional }}
+{{- $pages := sort .Pages "Title" "asc" }}
+{{- range $pages }}
+- [{{ .Title }}]({{ .RelPermalink }}index.html.md){{ with .Description }}: {{ . }}{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else -}}
+{{- .RawContent | .Page.RenderString -}}
+{{- end -}}

--- a/layouts/partials/markdown/include_entrypoint.md
+++ b/layouts/partials/markdown/include_entrypoint.md
@@ -1,0 +1,5 @@
+{{- $content := . -}}
+{{- $content = partial "markdown/include_shortcode_content.md" $content -}}
+{{- $content = partial "markdown/include_runtimes_versions.md" $content -}}
+{{- $content = partial "markdown/include_software_versions_shared_dedicated.md" $content -}}
+{{ $content }}

--- a/layouts/partials/markdown/include_runtimes_versions.md
+++ b/layouts/partials/markdown/include_runtimes_versions.md
@@ -1,0 +1,33 @@
+{{- $content := . -}}
+{{- $runtimesPattern := "\\{\\{<\\s*runtimes_versions\\s+([^>]+)\\s*>\\}\\}" -}}
+
+{{- range $runtimeFound := findRE $runtimesPattern $content -}}
+    {{- $runtime := replaceRE $runtimesPattern "$1" $runtimeFound -}}
+    {{- $runtime := lower (strings.TrimSpace $runtime) -}}
+    {{- $versions := index site.Data.runtime_versions $runtime -}}
+    {{- $output := "" -}}
+
+    {{- with $versions -}}
+        {{- if .default -}}
+            {{- $output = printf "%s### Default version\n" $output -}}
+            {{- range .default -}}
+                {{- $output = printf "%s- %s\n" $output . -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{- if .accepted -}}
+            {{- $output = printf "%s\n### Accepted version(s)\n" $output -}}
+            {{- range .accepted -}}
+                {{- $output = printf "%s- %s\n" $output . -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{- if .eol_source -}}
+            {{- $output = printf "%s\nCheck the [end-of-life (EOL)](%s) status of these versions." $output .eol_source -}}
+        {{- end -}}
+    {{- end -}}
+
+    {{- $content = replace $content $runtimeFound $output -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/markdown/include_shortcode_content.md
+++ b/layouts/partials/markdown/include_shortcode_content.md
@@ -1,0 +1,13 @@
+{{- $content := . -}}
+{{- $patternSearch := "\\{\\{%\\s*content/([^%}]+)\\s*%\\}\\}" -}}
+{{- $patternClean := "\\{\\{%\\s*content/(.+?)\\s*%\\}\\}" -}}
+
+{{- range $shortcodeFound := findRE $patternSearch $content -}}
+    {{- $name := replaceRE $patternClean "$1" $shortcodeFound -}}
+    {{- $filepath := printf "layouts/shortcodes/content/%s.md" $name -}}
+    {{- with os.ReadFile $filepath -}}
+        {{- $content = replace $content $shortcodeFound . -}}
+    {{- end -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/markdown/include_software_versions_shared_dedicated.md
+++ b/layouts/partials/markdown/include_software_versions_shared_dedicated.md
@@ -1,0 +1,23 @@
+{{- $content := . -}}
+{{- $versionsPattern := "\\{\\{<\\s*software_versions_shared_dedicated\\s+([^>]+)\\s*>\\}\\}" -}}
+
+{{- range $versionFound := findRE $versionsPattern $content -}}
+    {{- $dbname := replaceRE $versionsPattern "$1" $versionFound -}}
+    {{- $versions := index site.Data.software_versions_shared_dedicated $dbname -}}
+    {{- $output := "### Regular versions\n" -}}
+    {{- with $versions.dedicated -}}
+        {{- range . -}}
+            {{- $output = printf "%s- %s\n" $output . -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if $versions.dev -}}
+        {{- $output = printf "%s\n### DEV plan\n" $output -}}
+        {{- range $versions.dev -}}
+            {{- $output = printf "%s- %s\n" $output . -}}
+        {{- end -}}
+        {{- $output = printf "%s\n%s" $output site.Data.software_versions_shared_dedicated.dev_message -}}
+    {{- end -}}
+    {{- $content = replace $content $versionFound $output -}}
+{{- end -}}
+
+{{- return $content -}}


### PR DESCRIPTION
## Describe your PR

This PR add `llms.txt` standard support to the documentation through a new `LLMS` output format.

It creates a `llms.txt` file at the root of the project with:
- Documentation title
- Documentation description (in most part from quickstart section)
- List non empty documentation sections
- Creates a `.md` version of all sections pages, including shortcodes
- List all `.md` pages links and their description
- List all guides in `optional` section (as they're not mandatory to understand to use Clever Cloud