### PR TITLE
Upgrade Hugo to v0.140.2 and Hextra to v0.9.3

### DIFF
--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -9,7 +9,7 @@ jobs:
   changed_files:
     runs-on: ubuntu-latest
     name: Test changed-files
-    environment: PR review apps
+    environment: update doc
     # Needed to post comments and create issues
     permissions:
         issues: write

--- a/.github/workflows/external-doc-update.yml
+++ b/.github/workflows/external-doc-update.yml
@@ -9,6 +9,7 @@ jobs:
   changed_files:
     runs-on: ubuntu-latest
     name: Test changed-files
+    environment: PR review apps
     # Needed to post comments and create issues
     permissions:
         issues: write

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -31,9 +31,9 @@ jobs:
           ORGA_ID: ${{ secrets.ORGA_ID }}
           GH_CC_PRE_BUILD_HOOK: './clevercloud-deploy-script.sh'
           GH_CC_WEBROOT: '/public'
-          GH_HEXTRA_VERSION: 'v0.9.0'
+          GH_HEXTRA_VERSION: 'v0.9.3'
           GH_HUGO_ENV: 'production'
-          GH_HUGO_VERSION: '0.140.0'
+          GH_HUGO_VERSION: '0.140.2'
 
         with:
           type: 'static-apache'

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/CleverCloud/documentation
 
 go 1.21
 
-require github.com/imfing/hextra v0.9.0 // indirect
+require github.com/imfing/hextra v0.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/imfing/hextra v0.8.4 h1:cR4asr0TeDlqHPHLdTpMQJOjVeXnq8nfLMzcF0pld+w=
-github.com/imfing/hextra v0.8.4/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
-github.com/imfing/hextra v0.9.0 h1:1UyLZgS1eayce2ETCOjAQssXpkRz3HDrIs/fljH0lkU=
-github.com/imfing/hextra v0.9.0/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.9.3 h1:p4vDm2TSgt3RpJdJm2mqkpoJCH2S08wzySyyYodtgCc=
+github.com/imfing/hextra v0.9.3/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -13,7 +13,7 @@ module:
   hugoVersion:
     extended: true
     min: "0.133.0"
-    max: "0.140.0"
+    max: "0.140.2"
 
 outputs:
   home: [HTML, LLMS]


### PR DESCRIPTION
## Describe your PR

**Upgrades (no breaking changes):**

- Hugo from v0.140.0  to [v0.140.2](https://github.com/gohugoio/hugo/releases/tag/v0.140.2)
- Hextra from v0.9.0 to [v.0.9.3](https://github.com/imfing/hextra/releases/tag/v0.9.3)

**Security update in `external-doc-update.yml`:**

Use the environment parameter in job to avoid giving forks access  to repository secrets.

_The only secret used is `GITHUB_TOKEN`, which is ephemeral: a new one is generated for each job and revoked after the job ends._


## Checklist

- [ ] My PR is related to an opened issue : 
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @cnivolle 

