### PR TITLE
fix(nodejs): different env vars should not be in the code block

### DIFF
--- a/content/doc/applications/javascript/nodejs.md
+++ b/content/doc/applications/javascript/nodejs.md
@@ -92,8 +92,8 @@ Here are various scenarios:
 
 * `CC_NODE_DEV_DEPENDENCIES=install`: Development dependencies will be installed.
 * `CC_NODE_DEV_DEPENDENCIES=ignore`: Development dependencies will not be installed.
-* `NODE_ENV=production, CC_NODE_DEV_DEPENDENCIES=install`: Development dependencies will be installed.
-* `NODE_ENV=production, CC_NODE_DEV_DEPENDENCIES=ignore`: Development dependencies will not be installed.
+* `NODE_ENV=production` and `CC_NODE_DEV_DEPENDENCIES=install`: Development dependencies will be installed.
+* `NODE_ENV=production` and `CC_NODE_DEV_DEPENDENCIES=ignore`: Development dependencies will not be installed.
 * `NODE_ENV=production`: Package manager (NPM / Yarn) default behavior. Development dependencies will not be installed.
 * Neither `NODE_ENV` nor `CC_NODE_DEV_DEPENDENCIES` are defined: Package manager (NPM / Yarn) default behavior. Development dependencies will be installed.
 
@@ -182,7 +182,7 @@ To deploy an  application with pnpm, set the following environment variables:
 {{< tabs items="npm, Corepack" >}}
 
   {{< tab >}}**Install with `npm`**:
-  
+
   ```bash
   CC_NODE_BUILD_TOOL="custom"
   CC_PRE_BUILD_HOOK="npm install -g pnpm"
@@ -192,7 +192,7 @@ To deploy an  application with pnpm, set the following environment variables:
   {{< /tab >}}
 
   {{< tab >}}**Enable with Corepack**:
-  
+
   ```bash
   CC_NODE_BUILD_TOOL="custom"
   CC_PRE_BUILD_HOOK="corepack enable pnpm"


### PR DESCRIPTION
## Describe your PR

different env vars should not be in the code block

## Checklist

- [x] My PR is related to an opened issue : no
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

