### PR TITLE
remove mention of python.json

### DIFF
--- a/content/guides/python-django-sample.md
+++ b/content/guides/python-django-sample.md
@@ -36,7 +36,7 @@ If you want to test easily a Django deployment on Clever Cloud, just clone the [
 ### My application already exists
 
 {{< callout type="warning" >}}
-  Do not forget to add the `CC_PYTHON_MODULE` environment variable  or the file [clevercloud/python.json](https://github.com/CleverCloud/django-example/blob/master/clevercloud/python.json) in any Python project so that we get your required modules.
+  Do not forget to add the `CC_PYTHON_MODULE` environment variable in any Python project so that we get your required modules.
 {{< /callout >}}
 
 ### Fine tuning the application


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : 
The python.json file is a legacy tool we do not recommend to use anymore. Instead, we say to use CC_PYTHON_MODULE.
There was still a mention of using python.json in the Django documentation that is not needed anymore.
There is no need to leave this mention of the file as it would only lead to confusion since we don't document it in the other part of the doc.

## Checklist

- [x] My PR is related to an opened issue : #468 
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

