### PR TITLE
Add minimum version for blackFire

### DIFF
--- a/content/doc/metrics/blackfire.md
+++ b/content/doc/metrics/blackfire.md
@@ -24,6 +24,7 @@ Blackfire can be used on Clever Cloud with **PHP** applications.
 
 ### Necessary information
 
+Your PHP version must be 7.4 or higher.  
 Before setting up your app, be sure to have a [Blackfire Account](https://www.blackfire.io/).
 
 ### Configuration


### PR DESCRIPTION
## Describe your PR

We support BlackFire with clever cloud only on PHP version 7.4 minimum.
This information wasn't in the documentation before.

## Checklist

- [x] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

