### PR TITLE
fix(typo): Update CONTRIBUTING.md -- moral vs morale

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Priority goes to PRs that reference a problem addressed in an issue fitting the 
 
 ### 🥸 When reviewing a PR
 
-- **Latency:** Long PR review latency can be disappointing for the authors, and make merge conflicts arise in their branch. Long latency kills productivity and moral, so make sure to review PRs in a timely manner.
+- **Latency:** Long PR review latency can be disappointing for the authors, and make merge conflicts arise in their branch. Long latency kills productivity and morale, so make sure to review PRs in a timely manner.
 - **Don't nitpick:** If the PR respects the preceding standards and provide updated content, don't ask for changes just for the sake of it. If you think something isn't perfect, but it's not a big deal, don't ask for changes.
 - **Provide alternatives:** If you think the author needs to change something, provide an example to illustrate your point. Use the `suggestion` feature on GitHub so the author can commit it directly if they agree with it.
 - **It's OK to make mistakes:** Explain what's wrong, why, and how to improve. If someone is violating a standard, refer to this doc to explain.


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : explain what, how, and why. Be as explicict as you can on why your changes are needed and avoid implicit reasoning._

I'm guessing the intended word in this context is `morale` with an `e` at the end.

> Moral and morale differ by one letter, which makes them easy to confuse. Moral can function as an adjective concerned with the principles of right and wrong (a “moral obligation”) or as a noun referring to practices or modes of conduct (to have “good morals”). Morale, on the other hand, functions exclusively as a noun and refers to a sense of enthusiasm shared by a group (“the morale was low”).

https://www.merriam-webster.com/grammar/moral-vs-morale-difference-usage


## Checklist

- [ N/A ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)

I guesse I am currently proving that I've read the guidelines. 😉


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

