### PR TITLE
fix: remove incorrect mention of the number of IP ranges (Paris region)

### DIFF
--- a/content/doc/administrate/network.md
+++ b/content/doc/administrate/network.md
@@ -64,7 +64,7 @@ Clever Cloud may change these ranges at any moment while we expand our infrastru
 filtering source IPs is important to you, please check this page, or opt into our Unique
 IP service or a VPN Service.
 
-Please note that allowing all four ranges means you "allow" **all Clever Cloud
+Please note that allowing all ranges means you "allow" **all Clever Cloud
 applications** running in the Paris region to access that service.
 This means you should not base all that service security solely on filtering source IPs!
 


### PR DESCRIPTION
## Describe your PR

Documentation mentions 4 IP ranges whereas there are only 2 these days. I guess having the number of ranges does not bring any value (because said ranges are specified few lines ahead) so I removed it so it won't be out of sync again.


## Checklist

- [x] ~~My PR is related to an opened issue~~
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers

@davlgd 

