### PR TITLE
Fix incorrect name for Monitoring header

### DIFF
--- a/content/doc/find-help/faq.md
+++ b/content/doc/find-help/faq.md
@@ -224,7 +224,7 @@ For instance, you cannot create a Matomo add-on until you provide these details.
 
 ## I get unknown regular requests, is there a problem ? 
 
-The platform performs routine health checks to applications every 2 minutes. You may notice these periodic HTTP requests in your logs, with `X-Clever-Monitoring` header. They're part of Clever Cloud's standard monitoring process.
+The platform performs routine health checks to applications every 2 minutes. You may notice these periodic HTTP requests in your logs, with `X-Clevercloud-Monitoring` header. They're part of Clever Cloud's standard monitoring process.
 
 ## What is a DEV plan ? 
 


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : The header to identify that a request come from monitoring is called X-Clevercloud-Monitoring and not X-Clever-Monitoring.


## Checklist

- [x] My PR is related to an opened issue : #521 
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

fixes #521 

