### PR TITLE
update: hugo v0.140=>v0.145 and hextra 0.9.4 => 0.9.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Build fork
         env:
-          HUGO_VERSION: '0.140.2'
-          HEXTRA_VERSION: 'v0.9.4'
+          HUGO_VERSION: '0.145.0'
+          HEXTRA_VERSION: 'v0.9.5'
         run: ./clevercloud-deploy-script.sh
       
       - name: Upload artifact

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/CleverCloud/documentation
 
 go 1.21
 
-require github.com/imfing/hextra v0.9.3 // indirect
+require github.com/imfing/hextra v0.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.9.3 h1:p4vDm2TSgt3RpJdJm2mqkpoJCH2S08wzySyyYodtgCc=
-github.com/imfing/hextra v0.9.3/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.9.5 h1:lG6wnklT9PNLepq69Gj3GZyHRUkBWwv6bkPVL9yAcIQ=
+github.com/imfing/hextra v0.9.5/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -13,7 +13,7 @@ module:
   hugoVersion:
     extended: true
     min: "0.133.0"
-    max: "0.140.2"
+    max: "0.145.0"
 
 outputs:
   home: [HTML, LLMS]


### PR DESCRIPTION
## Describe your PR

This PR updates both Hugo and Hextra. Relevant changes, some of which we could now leverage as features are the following:

### Hugo ([releases](https://github.com/gohugoio/hugo/releases))

- handle inline HTML comments
- don't re-render aliases on server rebuilds
- remove leading whitespaces produced by Youtube shortcode
- deprecated shortcodes:
  - comments
  - gist

### Hextra ([release](https://github.com/imfing/hextra/releases/tag/v0.9.5))

- describe page last modification date
- hide navbar on mobile when heading links clicked
- add optional pagination control for blog articles

## Checklist

- [ ] My PR is related to an opened issue : #
- [ ] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

