### PR TITLE
Doc : Add mention that invoices are sent to primary and secondary mail

### DIFF
--- a/content/doc/billing/payments-invoicing.md
+++ b/content/doc/billing/payments-invoicing.md
@@ -66,6 +66,6 @@ Mandate:
 
 ### About invoices issuance and notifications
 
-As explained in the [Monthly Invoice documentation]({{< ref "doc/billing/unified-invoices.md#monthly-invoice" >}}), Clever Cloud issues an invoice at the beginning of every month.
-The invoice is emailed to you.
+As explained in the [Monthly Invoice documentation]({{< ref "doc/billing/unified-invoices.md#monthly-invoice" >}}), Clever Cloud issues an invoice at the beginning of every month.  
+The invoice is emailed to you. It's sent to both the primary and secondary mail of every Admin or Accountant in the organization.  
 In accordance with SEPA rules and the mandate your agreed to, this email also notifies you that a debit will be attempted 5 days after invoice issuance.

--- a/content/doc/billing/payments-invoicing.md
+++ b/content/doc/billing/payments-invoicing.md
@@ -67,5 +67,5 @@ Mandate:
 ### About invoices issuance and notifications
 
 As explained in the [Monthly Invoice documentation]({{< ref "doc/billing/unified-invoices.md#monthly-invoice" >}}), Clever Cloud issues an invoice at the beginning of every month.  
-The invoice is emailed to you. It's sent to both the primary and secondary mail of every Admin or Accountant in the organization.  
+This invoice is sent to both primary and secondary email address of any Admin or Accountant within the organization.  
 In accordance with SEPA rules and the mandate your agreed to, this email also notifies you that a debit will be attempted 5 days after invoice issuance.


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : Added mention that invoices are sent to both the primary and secondary mail of the admin and accountant in an organization.
This wasn't mentioned before and can be confusing when it is stated in the console that secondary mail receive no notifications.


## Checklist

- [x] My PR is related to an opened issue : #540 
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

