### PR TITLE
feat(materia): document and changelog JSON functions

### DIFF
--- a/content/changelog/2025/03-12-materia-kv-json.md
+++ b/content/changelog/2025/03-12-materia-kv-json.md
@@ -1,0 +1,23 @@
+---
+title: Materia KV with JSON commands (GET/SET/DEL)
+description: Added JSON functions to Materia KV
+date: 2025-03-12
+tags:
+  - Materia KV
+  - JSON
+authors:
+  - name: Enora Broudic
+    link: https://github.com/RaspY737
+    image: https://github.com/RaspY737.png?size=40
+  - name: Pierre Zemb
+    link: https://github.com/pierrez
+    image: https://github.com/pierrez.png?size=40
+excludeSearch: true
+---
+
+Materia KV now supports some `JSON` commands :
+- `JSON.SET`: sets JSON value at path in key
+- `JSON.GET`: gets JSON value at path from key
+- `JSON.DEL`: deletes JSON value at path from key
+
+These commands are available for new and already deployed add-ons, with no additional configuration. For detailed examples and usage, see [Materia KV documentation](/developers/doc/addons/materia-kv/#json-functions). If you have any questions or feedback, let's discuss it on our [GitHub Community](https://github.com/CleverCloud/Community/discussions/categories/materia).

--- a/content/doc/addons/materia-kv.md
+++ b/content/doc/addons/materia-kv.md
@@ -125,7 +125,8 @@ We've prepared a few examples to help you get started with Materia KV:
 * [Materia KV Go client](https://github.com/CleverCloud/mkv-go-cli)
 * [Materia KV raw TCP V demo](https://github.com/CleverCloud/mkv-raw-tcp-v)
 * [Materia KV raw TCP Ruby demo](https://github.com/CleverCloud/mkv-raw-tcp-ruby)
-
+* [Materia KV PHP sessions with TTL demo](https://github.com/CleverCloud/php-sessions-kv-example)
+*
 ### Supported types and commands
 
 During this alpha stage, we don't provide 100% compatibility with the Redis API. Currently supported value types are:


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : explain what, how, and why. Be as explicict as you can on why your changes are needed and avoid implicit reasoning._
This pull request includes updates to the Materia KV documentation to introduce and explain new JSON functions. The changes include a new changelog entry, updates to the list of supported commands, and detailed examples and limitations of the JSON functions.

Documentation updates:

* [`content/changelog/2025/03-12-materia-kv-json.md`](diffhunk://#diff-453ad2afb454423eab4f207a6efd996633172fce2754b725ac049429e1def791R1-R26): Added a new changelog entry for JSON functions in Materia KV, including new commands and a link to the documentation.
* [`content/doc/addons/materia-kv.md`](diffhunk://#diff-0519774d0fc33316f115382c0c234a214d496af1d560aa20260740958d254d67R161-R163): Added `JSON.SET`, `JSON.GET`, and `JSON.DEL` commands to the list of supported commands.

Examples and usage:

* [`content/doc/addons/materia-kv.md`](diffhunk://#diff-0519774d0fc33316f115382c0c234a214d496af1d560aa20260740958d254d67R178-R230): Added a section with detailed examples of using JSON functions with `redis-cli`, including setting, getting, and deleting JSON values, as well as handling multiple paths and recursive searches.

Limitations:

* [`content/doc/addons/materia-kv.md`](diffhunk://#diff-0519774d0fc33316f115382c0c234a214d496af1d560aa20260740958d254d67R178-R230): Documented the current limitations of the JSON functions, such as restrictions on creating new fields in existing documents and nested path creation.


## Checklist

- [ ] My PR is related to an opened issue : #
- [ ] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

