### PR TITLE
Fix broken link in FAQ

### DIFF
--- a/content/doc/find-help/faq.md
+++ b/content/doc/find-help/faq.md
@@ -159,7 +159,7 @@ For reference, the table below lists the class file version for each major Java 
 
 Clever Cloud does not give you access to a server or a VPS, it makes your application run. Each instance is started and configured automatically, and can be stopped at any moment.
 
-If however, you still need SSH access for debugging purposes, please have a look at [SSH access](../../cli/ssh-access), but keep in mind that changes made on an instance are not persistent across deployments.
+If however, you still need SSH access for debugging purposes, please have a look at [SSH access](/developers/doc/administrate/ssh-clever-tools/), but keep in mind that changes made on an instance are not persistent across deployments.
 
 ## I want to user Clever Cloud on my own premises, is that possible?
 


### PR DESCRIPTION
## Describe your PR

In [FAQ page](https://www.clever-cloud.com/developers/doc/find-help/faq/#i-want-ssh-access-to-my-server), _'look at [SSH access](https://www.clever-cloud.com/developers/doc/cli/ssh-access)'_ is broken

The new link goes to: https://www.clever-cloud.com/developers/doc/administrate/ssh-clever-tools/