### PR TITLE
fix: no more long titles in sidebar

### DIFF
--- a/content/doc/addons/cellar.md
+++ b/content/doc/addons/cellar.md
@@ -1,6 +1,7 @@
 ---
 type: docs
-title: Cellar, a S3-like object storage service
+title: Cellar, S3-compatible object storage service
+linkTitle: Cellar Object Storage
 description: Cellar is an Amazon S3-compatible file storage system created and hosted by Clever Cloud.
 tags:
 - addons

--- a/content/doc/administrate/network.md
+++ b/content/doc/administrate/network.md
@@ -1,6 +1,7 @@
 ---
 type: docs
 title: Networking and IP addresses ranges
+linkTitle: Networking and IP
 position: 3
 shortdesc: What are my application's outgoing IP?
 keywords:

--- a/content/doc/administrate/ssh-clever-tools.md
+++ b/content/doc/administrate/ssh-clever-tools.md
@@ -1,6 +1,7 @@
 ---
 type: docs
 title: SSH access to running instances
+linkTitle: SSH access
 shortdesc: How to SSH access running instances on Clever Cloud
 tags:
 - administrate

--- a/content/doc/develop/healthcheck.md
+++ b/content/doc/develop/healthcheck.md
@@ -1,6 +1,7 @@
 ---
 type: docs
 title: Deployment healthcheck path
+linkTitle: Deployment healthcheck
 shortdesc: Healthcheck allows to check if an url return always the 200 code.
 tags:
 - develop

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -1,6 +1,7 @@
 ---
 type: docs
 title: Environment Variable Reference
+linktitle: EnvVar Reference
 position: 3
 shortdesc: List of all the environment variable references
 tags:


### PR DESCRIPTION
## Describe your PR

I've made some UI fixes in the titles that appear in the sidebar.
We don't change the `title`, but we add `linkTitle` with a shorter name.


## Checklist

- [ ] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
@CleverCloud/reviewers

