### PR TITLE
changelog: PG17 default

### DIFF
--- a/content/changelog/2025/03-27-postgresql-default.md
+++ b/content/changelog/2025/03-27-postgresql-default.md
@@ -1,0 +1,18 @@
+---
+title: PostgreSQL 17 is now the default on Clever Cloud
+date: 2025-03-27
+tags:
+  - addons
+  - update
+authors:
+  - name: David Legrand
+    link: https://github.com/davlgd
+    image: https://github.com/davlgd.png?size=40
+description: Let the magic happen!
+excludeSearch: true
+---
+
+As [PostgreSQL 16 and 17 are available](/developers/changelog/2025/03-18-postgresql-16-17/) on Clever Cloud, we start using PostgreSQL 17 as the default version for new add-ons. **Starting today**, when you create a new PostgreSQL database, it will be setup with PostgreSQL 17.
+
+* [PostgreSQL versioning policy](https://www.postgresql.org/support/versioning/)
+* [Learn more about PostgreSQL on Clever Cloud](/developers/doc/addons/postgresql/)


### PR DESCRIPTION
## Describe your PR

This PR adds an entry about PG17 being the default for new created PG databases.

