### PR TITLE
Fix : typo for tailscale environnement variable 

### DIFF
--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -127,7 +127,7 @@ Note that `Reusable keys` are required to use multiple instances. You can [gener
 |  Name  |  Description  |  Default value  |
 |-----------------------|------------------------------|--------------------------------|
 | [`TAILSCALE_ACCEPT_DNS`](https://tailscale.com/kb/1072/client-preferences#use-tailscale-dns-settings) | Tailscale use its default DNS settings | `true` |
-| [`TAILSCALE_ACCEPT_ROUTE`](https://tailscale.com/kb/1072/client-preferences#use-tailscale-subnets) | Tailscale uses its subnets settings | `false` |
+| [`TAILSCALE_ACCEPT_ROUTES`](https://tailscale.com/kb/1072/client-preferences#use-tailscale-subnets) | Tailscale uses its subnets settings | `false` |
 | [`TAILSCALE_AUTH_KEY`](https://tailscale.com/ "tailscale.com") | Contains your Tailscale Auth key | |
 | `TAILSCALE_LOGIN_SERVER`| Contains the login server | |
 


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here : The environnement variable reference page showed that the variable to use accept-routes was called `TAILSCALE_ACCEPT_ROUTE`, but it lack the S at the end.  
The correct one is `TAILSCALE_ACCEPT_ROUTES`

## Checklist

- [x] My PR is related to an opened issue : #
- [x] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

