### PR TITLE
Simplify deploy script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,11 @@ jobs:
 
       - name: Build fork
         env:
-          HUGO_VERSION: '0.146.7'
-          HEXTRA_VERSION: 'v0.9.7'
-        run: ./clevercloud-deploy-script.sh
+          HUGO_VERSION: '0.147.8'
+        run: |
+          HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz"
+          wget -qO- ${HUGO_URL} | tar -xz -C /usr/local/bin
+          ./clevercloud-deploy-script.sh
 
       - name: Upload artifact
         id: artifact-upload-step

--- a/clevercloud-deploy-script.sh
+++ b/clevercloud-deploy-script.sh
@@ -1,6 +1,4 @@
-wget https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
-tar xvf hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
-chmod +x ./hugo
-./hugo mod get github.com/imfing/hextra@$HEXTRA_VERSION
-./hugo --gc --minify --destination public/developers
+#! /bin/bash
+
+hugo --gc --minify
 echo "AddType text/markdown;charset=UTF-8 .md" > public/.htaccess


### PR DESCRIPTION
## Describe your PR

This PR simplifies the deployment script regarding recent images update:
- Hugo is now included in images and there is no need to download it anymore
- Hugo version is set by the new `CC_HUGO_VERSION` environment variable
- The theme is downloaded by hugo during build from the `go.mod` file
- Default destination works right with the documentation/domain

I've updated the build workflow accordingly, as it relies on Ubuntu and needs to download Hugo.