### PR TITLE
fix: Use usefull information in links

### DIFF
--- a/content/README.md
+++ b/content/README.md
@@ -5,4 +5,4 @@ This repo contains all the content from the [Clever Cloud Doc](https://developer
 
 This repo is automatically updated with a Git hook at the same time the main project is.
 
-Find all updates and contibuting guidelines on the main repo [here](https://github.com/CleverCloud/documentation).
+Find [all updates and contributing guidelines on the main repository](https://github.com/CleverCloud/documentation).

--- a/content/changelog/2023/11-29-api-update.md
+++ b/content/changelog/2023/11-29-api-update.md
@@ -42,4 +42,4 @@ For years, you can deploy applications on Clever Cloud as a `Task` with the API 
 }
 ```
 
-You can read the full APIv2 documentation [here](/developers/api/v2).
+- [Read the full APIv2 documentation](/developers/api/v2)

--- a/content/changelog/2024/01-11-redis-7.2.4.md
+++ b/content/changelog/2024/01-11-redis-7.2.4.md
@@ -26,4 +26,4 @@ Redis™ `7.2.4` is now available for each new deployment. You can easily migrat
 * Fix slot ownership not being properly handled when deleting a slot from a node (#12564)
 * Fix atomicity issues with the RedisModuleEvent_Key module API event (#12733)
 
-Learn more about Redis™ 7.2.x branch [here](https://redis.com/blog/introducing-redis-7-2/).
+- [Learn more about Redis™ 7.2.x branch](https://redis.com/blog/introducing-redis-7-2/).

--- a/content/changelog/2024/01-24-ruby-3.3.0.md
+++ b/content/changelog/2024/01-24-ruby-3.3.0.md
@@ -16,7 +16,7 @@ excludeSearch: true
 
 You can now choose the `3.3.0` release of Ruby when you deploy Ruby on Rails applications on Clever Cloud. It can be set either through your `Gemfile` or the `CC_RUBY_VERSION` [environment variable](/developers/doc/reference/reference-environment-variables/#ruby).
 
-* Learn more about Ruby 3.3.0 release [here](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)
+* [Learn more about Ruby 3.3.0 release](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)
 
 {{< callout type="info" >}}
   If you use Node.js on this image, be aware that default version is now 20.11.0 (LTS). If you need another release to deploy your application, set the `CC_NODE_VERSION` [environment variable](/developers/doc/develop/env-variables/).

--- a/content/changelog/2024/02-16-clever-tools-3.4.0.md
+++ b/content/changelog/2024/02-16-clever-tools-3.4.0.md
@@ -17,7 +17,7 @@ aliases:
 excludeSearch: true
 ---
 
-This week, we published two Clever Tools updates in a row. 3.3.0 was about adding [our new Gravelines HDS region](../02-12-new-grahds-region/) support and fixing a bug in our add-ons logs feature. 3.4.0 brings `json` and `json-stream` formats for applications logs. The latter uses the Newline delimited JSON (NDJSON) specification (`jq` compatible). You can learn more about it [here](https://github.com/ndjson/ndjson-spec/blob/master/README.md).
+This week, we published two Clever Tools updates in a row. 3.3.0 was about adding [our new Gravelines HDS region](../02-12-new-grahds-region/) support and fixing a bug in our add-ons logs feature. 3.4.0 brings `json` and `json-stream` formats for applications logs. The latter uses the Newline delimited JSON (NDJSON) specification (`jq` compatible). You can learn more about [ndjson/ndjson-spec/ on GitHub](https://github.com/ndjson/ndjson-spec/blob/master/README.md).
 
 But it's the `create` and `deploy` commands which are the most improved by this release. First, you'll now get the application or add-on name confirmed after creation. You can also get a JSON response adding `--format json` or `-F json` to the `create` or `create-addon` command. Second, the current folder name is now used as default application name if none is provided.
 

--- a/content/changelog/2024/07-03-docker-terraform.md
+++ b/content/changelog/2024/07-03-docker-terraform.md
@@ -19,6 +19,6 @@ excludeSearch: true
 
 To manage your resources as code on Clever Cloud, from applications to add-ons (object storage, databases, etc.), you can use our Terraform provider. It's compatible with tools such as [OpenTofu](https://opentofu.org/) and can now deploy applications using [our Docker runtime](/developers/doc/applications/docker/).
 
-You can define instances count or flavors, region, dependencies, ports, Dockerfile and application paths, registry credentials and more. Full parameters list is available [here](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs/resources/docker).
+You can define instances count or flavors, region, dependencies, ports, Dockerfile and application paths, registry credentials and more. Read [the full parameters list](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs/resources/docker).
 
 * Learn more about [our Terraform provider](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs)

--- a/content/changelog/2024/07-11-pulsar-3.3.0-update.md
+++ b/content/changelog/2024/07-11-pulsar-3.3.0-update.md
@@ -14,6 +14,6 @@ aliases:
 excludeSearch: true
 ---
 
-3.3.0 release of Apache Pulsar is deployed on our platform. It brings lots of fixes and some new features. Full changelog is [here](https://github.com/apache/pulsar/releases/tag/v3.3.0).
+[Apache Pulsar 3.3.0](https://github.com/apache/pulsar/releases/tag/v3.3.0) is deployed on our platform. It brings lots of fixes and some new features.
 
 - Learn more about [Apache Pulsar](https://www.clever-cloud.com/product/pulsar/) on Clever Cloud

--- a/content/changelog/2024/08-26-java-containers-update.md
+++ b/content/changelog/2024/08-26-java-containers-update.md
@@ -17,6 +17,6 @@ aliases:
 excludeSearch: true
 ---
 
-As part of our images enhancement process, we've tidied up the [list of supported servlet containers](/developers/doc/applications/java/java-war/#available-containers). Those that are not longer used by our customers are removed from the Java image. If you need a container which is not listed [here](/developers/doc/applications/java/java-war/#available-containers) or a specific version, please contact [our support team](https://console.clever-cloud.com/ticket-center-choice). This release also includes a [Wildfly](https://github.com/wildfly/wildfly) upgrade. Versions 27.0.1 and 33.0.1 are now available.
+As part of our images' enhancement process, we've tidied up the [list of supported servlet containers](/developers/doc/applications/java/java-war/#available-containers). Those that are no longer used by our customers are removed from the Java image. If you need a container which is not listed in [the servlet container list](/developers/doc/applications/java/java-war/#available-containers) or a specific version, please contact [our support team](https://console.clever-cloud.com/ticket-center-choice). This release also includes a [Wildfly](https://github.com/wildfly/wildfly) upgrade. Versions 27.0.1 and 33.0.1 are now available.
 
 - Learn more about [Java on Clever Cloud](/developers/doc/applications/java/)

--- a/content/changelog/2024/10-01-materia-kv-ttl-layer-update.md
+++ b/content/changelog/2024/10-01-materia-kv-ttl-layer-update.md
@@ -16,7 +16,8 @@ excludeSearch: true
 
 After the first release of our [Materia KV add-on](/developers/doc/addons/materia-kv), we discussed with users and what they wanted to see in the next version. A major milestone for us was to add support for `TTL` (Time To Live) command, and those related to it such as `EXPIRE`, `PEXPIRE`, `PTTL`, `SET EX`. It's now available and will helps us, for example, to bring Materia KV support to PHP sessions.
 
-This new release of our Redis API compatible layer brings a new design, helping us to better support more commands in the future. In the meantime, we've retired hash and list commands, to enhance them. They will be back soon. Some others are added, like `CLIENT ID`, `DECRBY`, `INCRBY`,`GETBIT`, `SETBIT`, etc. The full list is available [here](/developers/doc/addons/materia-kv/#supported-types-and-commands).
+This new release of our Redis API compatible layer brings a new design, helping us to better support more commands in the future. In the meantime, we've retired hash and list commands, to enhance them. They will be back soon. Some others are added, like `CLIENT ID`, `DECRBY`, `INCRBY`,`GETBIT`, `SETBIT`, etc.
 
 If you have any questions or feedback, let's discuss it on our [GitHub Community](https://github.com/CleverCloud/Community/discussions/categories/materia).
 
+- [The full Materia KV commands list](/developers/doc/addons/materia-kv/#supported-types-and-commands).

--- a/content/changelog/2024/10-28-pulsar-4.0.0-update.md
+++ b/content/changelog/2024/10-28-pulsar-4.0.0-update.md
@@ -14,6 +14,6 @@ aliases:
 excludeSearch: true
 ---
 
-4.0.0 release of Apache Pulsar is deployed on our platform. It brings lots of new features and fixes, including enhanced `Key_Shared` subscription implementation, which helps us to resolve some recent issues. Full changelog is [here](https://github.com/apache/pulsar/releases/tag/v4.0.0).
+[4.0.0 release of Apache Pulsar](https://github.com/apache/pulsar/releases/tag/v4.0.0) is deployed on our platform. It brings lots of new features and fixes, including enhanced `Key_Shared` subscription implementation, which helps us to resolve some recent issues.
 
 - Learn more about [Apache Pulsar](https://www.clever-cloud.com/product/pulsar/) on Clever Cloud

--- a/content/doc/account/ssh-keys-management.md
+++ b/content/doc/account/ssh-keys-management.md
@@ -86,7 +86,7 @@ ssh-keygen -t ecdsa-sk -C "your_email@youremail.com"
 ```
 
 {{< callout type="info" >}}
-  You can use options related to security devices adding them with the `-O` argument (for example `-O resident`). They're detailed [here](https://man.openbsd.org/ssh-keygen#FIDO_AUTHENTICATOR).
+  You can use options related to security devices adding them with the `-O` argument (for example `-O resident`). They're detailed in [ssh-keygen's man page](https://man.openbsd.org/ssh-keygen#FIDO_AUTHENTICATOR).
 {{< /callout >}}
 
 ## Checking of existing SSH keys
@@ -138,7 +138,7 @@ If you see "*access denied*" or "*password:*" when you [push on Clever Cloud](..
 
 ### Through CC API or Clever cURL
 
-You can also add a **public SSH key** from the command line with a simple cURL request to [our API]({{< ref "api" >}} "OpenAPI"). The simpler way to do that is to use our CLI, [Clever Tools](https://github.com/CleverCloud/clever-tools), and its `clever curl` command once logged in:  
+You can also add a **public SSH key** from the command line with a simple cURL request to [our API]({{< ref "api" >}} "OpenAPI"). The simpler way to do that is to use our CLI, [Clever Tools](https://github.com/CleverCloud/clever-tools), and its `clever curl` command once logged in:
 
 ```bash
 clever curl -X PUT -H "Content-Type: application/json" --data "\"$(cat ~/.ssh/yourkey.pub)\"" https://api.clever-cloud.com/v2/self/keys/newkeyname

--- a/content/doc/addons/cellar.md
+++ b/content/doc/addons/cellar.md
@@ -326,7 +326,7 @@ You only need to specify a custom endpoint (eg `cellar-c2.services.clever-cloud.
 
 ## Policies
 
-Cellar allows you to create policies to control the actions on your buckets. Find below two policies examples, and further documentation [here](https://docs.ceph.com/en/latest/radosgw/bucketpolicy/).
+Cellar allows you to create policies to control the actions on your buckets. Find below two policies examples, and [further documentation](https://docs.ceph.com/en/latest/radosgw/bucketpolicy/).
 
 ### Public bucket policy
 
@@ -386,8 +386,8 @@ The original ACL should apply to all of your objects after that.
 If you need to restrict your S3 Cellar to certain IPs, you can use a policy.
 To do so, you can use the template below in a `policy.json` file. This example show how to block actions from any IP that isn't `192.168.1.6`.
 
-- Replace the `<bucket-name>` with your bucket name in the policy file.  
-- Change the `Effect` to `Allow` or `Deny` depending on your needs.  
+- Replace the `<bucket-name>` with your bucket name in the policy file.
+- Change the `Effect` to `Allow` or `Deny` depending on your needs.
 - Change the IP address under `Condition` to select which IP should trigger the rule.
 
 ```json {filename="IP-restriction-policy.json"}
@@ -425,7 +425,7 @@ s3cmd setpolicy ./policy.json s3://<bucket-name>
 ```
 
 To delete the policy, use this command:
-``` 
+```
 s3cmd delpolicy ./policy.json s3://<bucket-name>
 ```
 

--- a/content/doc/addons/materia-kv.md
+++ b/content/doc/addons/materia-kv.md
@@ -114,7 +114,7 @@ By default, Materia KV uses TLS on the 6379 port. You can use non-TLS connection
 
 ### Clever KV
 
-We're exploring how [Clever Tools](https://github.com/CleverCloud/clever-tools/) can natively support Materia KV and helps you to manage such add-ons without any additional software or configuration. We've enabled the `clever kv` command in a testing branch available [here](https://github.com/CleverCloud/clever-tools/pull/725). You can download it as a binary and only need the `KV_TOKEN` environment variable to be set to use it, or target a specific add-on with the `--addon` option.
+We're exploring how [Clever Tools](https://github.com/CleverCloud/clever-tools/) can natively support Materia KV and helps you to manage such add-ons without any additional software or configuration. The `clever kv` command is available since [version 3.11](https://github.com/CleverCloud/clever-tools/releases/tag/3.11.0).
 
 * [Learn more about Clever KV](/developers/doc/cli/kv-stores/)
 

--- a/content/doc/addons/mongodb/_index.md
+++ b/content/doc/addons/mongodb/_index.md
@@ -38,7 +38,7 @@ DEV plan is no longer available for MongoDB.
 
 ### Important note about fair use on DEV plans
 
-Heavy usage of DEV databases may impact the shared cluster they rely upon. It will degrade performance of the other databases. To that extent, DEV plan has a limit of **15 operations/second**. Going above the limit might disconnect your database. 
+Heavy usage of DEV databases may impact the shared cluster they rely upon. It will degrade performance of the other databases. To that extent, DEV plan has a limit of **15 operations/second**. Going above the limit might disconnect your database.
 
 {{% content/db-backup %}}
 
@@ -71,7 +71,7 @@ To be able to use [Mongo Ops Manager](https://www.mongodb.com/products/ops-manag
 The features available with Mongo Ops Manager could be relevant if you managed your infrastructure and the maintenance of your MongoDB databases yourself. However, if you use Clever Cloud to access our Mongo add-ons, you are already opting for a managed service, and will therefore benefit from the following features similar to Mongo Ops Manager:
 
 - **A centralized interface** to access your database settings and perform operations on them.
-- **A monitoring and alert system** that can be configured with Grafana (an example with Slack alerts can be found [here](https://www.clever-cloud.com/blog/features/2021/12/03/slack-alerts-for-grafana/)).
+- **A monitoring and alert system** that can be configured with Grafana. See ([this example with Slack alerts](https://www.clever-cloud.com/blog/features/2021/12/03/slack-alerts-for-grafana/)).
 - **A backup and restore system** already configured for our add-ons (customizable upon request) with easy migration and one-click importation.
 - The ability to **automate tasks** with our CLI.
 - **Enhanced security** through our default access management on Clever Cloud (encryption at rest, default unauthorized super admin operations, etc.).

--- a/content/doc/addons/otoroshi.md
+++ b/content/doc/addons/otoroshi.md
@@ -111,7 +111,7 @@ Designed for production environments, the Coraza WAF plugin offers flexible conf
 
 ## Manage Otoroshi from its API
 
-Otoroshi exposes a comprehensive REST API that enables programmatic control over all operations available through the Otoroshi dashboard. The dashboard itself operates as a client of this API. It gives you full control over your Otoroshi instances, enabling you to build custom integrations and extensions tailored to your infrastructure needs. A Swagger UI detailing available endpoints is available [here](https://maif.github.io/otoroshi/swagger-ui/index.html).
+Otoroshi exposes a comprehensive REST API that enables programmatic control over all operations available through the Otoroshi dashboard. The dashboard itself operates as a client of this API. It gives you full control over your Otoroshi instances, enabling you to build custom integrations and extensions tailored to your infrastructure needs. [A Swagger UI detailing available endpoints is available](https://maif.github.io/otoroshi/swagger-ui/index.html).
 
 An OpenAPI descriptor is available from your instance:
 

--- a/content/doc/applications/golang/_index.md
+++ b/content/doc/applications/golang/_index.md
@@ -129,7 +129,7 @@ build:
 	go build -o ${BINARY} main.go
 ```
 
-You'll find a more complex project using a Go Workspace and a `Makefile` [here](https://github.com/CleverCloud/go-workspaces).
+- [A more complex project using a Go Workspace and a Makefile](https://github.com/CleverCloud/go-workspaces)
 
 {{< callout type="warning" >}}
   Using `clevercloud/go.json` to define Makefile and binary paths is a deprecated method and should no longer be used.

--- a/content/doc/applications/javascript/nodejs.md
+++ b/content/doc/applications/javascript/nodejs.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Overview
 
-Clever Cloud allows you to deploy any [Node.js](https://nodejs.org) application. We do support **any stable version of Node.js**. Their release schedule is available [here](https://nodejs.org/en/about/previous-releases). This page explains how to set up your application to run it on our service.
+Clever Cloud allows you to deploy any [Node.js](https://nodejs.org) application. We do support **any stable version of Node.js**. Learn more about [Node.js release schedule](https://nodejs.org/en/about/previous-releases). This page explains how to set up your application to run it on our service.
 
 ## Configure your Node.js application
 

--- a/content/doc/applications/ruby/_index.md
+++ b/content/doc/applications/ruby/_index.md
@@ -28,7 +28,7 @@ Ruby on Rails is an open source web application framework which runs on the Ruby
 Clever Cloud allows you to deploy any Ruby on Rails application. This page will explain you how to set up your application to run it on our service.
 You do not need to change a lot in your application, the *requirements* will help you configure your applications with some mandatory files to add, and properties to setup.
 
-You can find [here](https://GitHub.com/CleverCloudDemos/demo-rubyonrails-pg-rest) an example of Ruby on Rails application on Clever Cloud.
+- [An example of Ruby on Rails application on Clever Cloud](https://GitHub.com/CleverCloudDemos/demo-rubyonrails-pg-rest)
 
 {{% content/create-application %}}
 

--- a/content/doc/find-help/faq.md
+++ b/content/doc/find-help/faq.md
@@ -106,7 +106,7 @@ In order to use `request.secure` instead of accessing the header, you must add `
 
 ## PHP: `$_SERVER` auth variables are always empty, how do I make this work?
 
-It's explained [here](../../applications/php/#using-http-authentication).
+- [Lean more about the $_SERVER variable on Clever Cloud](../../applications/php/#using-http-authentication)
 
 ## How to get the user's IP address?
 
@@ -131,7 +131,7 @@ access them via git+ssh or sFTP), and you need a private key to connect to the s
 can commit them in your application's Clever Cloud repository and then add a
 `clevercloud/ssh.json` file.
 
-The ssh.json file is documented [here](../../reference/common-configuration/#private-ssh-key).
+- [Learn more about ssh.json](../../reference/common-configuration/#private-ssh-key)
 
 ## I get a `java.lang.UnsupportedClassVersionError: Unsupported major.minor version` error. How can I fix it?
 
@@ -214,7 +214,7 @@ If a VACUUM operation needs more disk that there is remaining, migrating to the 
 
 Clever Cloud stores all backups on [Cellar](https://www.clever-cloud.com/product/cellar-object-storage/), a replicated object storage service with three copies distributed across datacenters in the PAR region to ensure durability. Even if one datacenter fails, your backups remain safe.
 
-For custom configurations (for example, multiple retention policies), contact Support. To locate backups not visible in the Console, use [Clever Tools](https://github.com/CleverCloud/clever-tools) with: `clever database backups DATABASE-ID [--format, -F] FORMAT`.  Find more documentation on restoring backups with the CLI [here](/developers/doc/cli/addons/#database-backups).
+For custom configurations (for example, multiple retention policies), contact Support. To locate backups not visible in the Console, use [Clever Tools](https://github.com/CleverCloud/clever-tools) with: `clever database backups DATABASE-ID [--format, -F] FORMAT`.  Find more [documentation on restoring backups with the CLI](/developers/doc/cli/addons/#database-backups).
 
 
 ## I can't create my add-on

--- a/content/doc/metrics/warp10.md
+++ b/content/doc/metrics/warp10.md
@@ -69,11 +69,9 @@ The Clever Cloud Warp 10 endpoint is:
 https://c2-warp10-clevercloud-customers.services.clever-cloud.com/api/v0
 ```
 
-You can find documentation about endpoint gateway [here](https://www.warp10.io/content/03_Documentation/03_Interacting_with_Warp_10/01_Introduction).
+- Learn more about [endpoint gateway on warp10.io](https://www.warp10.io/content/03_Documentation/03_Interacting_with_Warp_10/01_Introduction)
 
-> You can find the endpoint and an available token under the `metric` tab of your application
-
-You can query our Warp 10 platform with your own script. Here's a curl example :
+You can find the endpoint and an available token under the `metric` tab of your application. You can query our Warp 10 platform with your own script. Here's an example with `curl`:
 
 ```bash
   curl -T <Path/to/a/warpscript_file> https://c2-warp10-clevercloud-customers.services.clever-cloud.com/api/v0/exec

--- a/content/doc/quickstart/_index.md
+++ b/content/doc/quickstart/_index.md
@@ -119,10 +119,7 @@ Choose the language or the framework you want to deploy.
 
 Horizontal scaling is the number of instances that can run at the same time. Vertical scaling sets the minimum and maximum size the instance can be.
 
-{{< callout emoji="💡" >}}
-  You can learn more about scaling & instances size [here](/developers/doc/administrate/scalability).
-  {{< /callout >}}
-
+- [Learn more about scaling & instances size](/developers/doc/administrate/scalability)
 
 #### Name your application
 

--- a/content/guides/ruby-on-rails.md
+++ b/content/guides/ruby-on-rails.md
@@ -21,7 +21,7 @@ Ruby on Rails is an open source web application framework which runs on the Ruby
 Clever Cloud allows you to deploy any Ruby on Rails application. This page will explain you how to set up your application to run it on our service.
 You do not need to change a lot in your application, the *requirements* will help you configure your applications with some mandatory files to add, and properties to setup.
 
-You can find [here](https://GitHub.com/CleverCloudDemos/demo-rubyonrails-pg-rest) an example of Ruby on Rails application on Clever Cloud.
+- [An example of Ruby on Rails application on Clever Cloud](https://GitHub.com/CleverCloudDemos/demo-rubyonrails-pg-rest)
 
 {{% content/create-application %}}
 

--- a/content/guides/ruby-rack.md
+++ b/content/guides/ruby-rack.md
@@ -36,7 +36,7 @@ Be sure that:
 
 ### Tutorial and sample app
 
-You can find an hello world tutorial of a Ruby and Rack application [here]({{< ref "/guides/ruby-rack-app-tutorial" >}}) and find the source code of the demo [here](https://github.com/CleverCloud/rack-example).
+- [An hello world tutorial of a Ruby and Rack application](/developers/guides/ruby-rack-app-tutorial)
 
  {{% content/new-relic %}}
 


### PR DESCRIPTION
don't use "here" in links

## Describe your PR

Don't use "here" in links. It doesn't give much context on the link, is bad for the user experience and accessibility.

https://ux.stackexchange.com/questions/12100/why-shouldnt-we-use-words-such-as-here-and-this-in-textlinks
## Checklist

- [ ] My PR is related to an opened issue : #
- [ ] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

