### PR TITLE
Add example for multiple auth to kibana

### DIFF
--- a/content/guides/kibana.md
+++ b/content/guides/kibana.md
@@ -50,6 +50,12 @@ To disable SSO authentication and use elastic users instead, you need to modify 
 
 Remember, you need to ask Clever Cloud Support team to grant superuser permissions to your user. After that, you will be able to add additional users via Kibana.
 
+### Multiple authentication methods
+
+If you need to allow for multiple authentication methods to your Kibana, you need to modify Kibana's configuration. We provide an example configuration file for Kibana 8.10.2:
+
+* https://raw.githubusercontent.com/CleverCloud/custom-kibana-config/master/8.10.2/sso-basic-8.10.2
+
 ### Add custom domain name
 
 You need to disable SSO authentication first. Then, you will be able to add a custom domain name in "Domain name" tab of your Kibana app.

--- a/content/guides/kibana.md
+++ b/content/guides/kibana.md
@@ -29,19 +29,24 @@ Kibana can be enabled at the add-on creation. Choose "Create an add-on" > "Elast
 
 ### Customize the Kibana configuration file
 
-The configuration is set with this deployment hook :
-`CC_PRE_RUN_HOOK` = `curl https://api.clever-cloud.com/v2/providers/es-addon/kibana-setup/<your elastic version> | sh`
+You can customize the Kibana configuration file by setting the `CC_PRE_RUN_HOOK` environment variable. This variable will be executed before the Kibana instance starts. By default, it is:
+
+```
+CC_PRE_RUN_HOOK` = `curl https://api.clever-cloud.com/v2/providers/es-addon/kibana-setup/<your elastic version> | sh`
+```
 
 To modify this default configuration ([Configuration file for Kibana 8.3.3](https://api.clever-cloud.com/v2/providers/es-addon/kibana-setup/8.3.3)), you need to host your own config file (we strongly recommend [Cellar](/developers/doc/deploy/addon/cellar)).
 
-Check other available configuration file on [Github](https://github.com/CleverCloud/custom-kibana-config)
+Check other available configuration file on [GitHub](https://github.com/CleverCloud/custom-kibana-config).
+
+> [!TIP]
+> If you use a custom configuration file, host it from your own Cellar add-on or any other trusted source.
 
 ### Disable SSO authentication
 
-To disable SSO authentication and use elastic users instead, you need to modify Kibana's configuration file and `CC_PRE_RUN_HOOK` in environment variables.
+To disable SSO authentication and use elastic users instead, you need to modify Kibana's configuration file. We provide an example configuration file for Kibana 8.3.3:
 
-For example for Kibana 8.3.3:
-`CC_PRE_RUN_HOOK` = `curl https://raw.githubusercontent.com/CleverCloud/custom-kibana-config/master/8.3.3/no-sso-8.3.3 | sh`
+* https://raw.githubusercontent.com/CleverCloud/custom-kibana-config/master/8.3.3/no-sso-8.3.3
 
 Remember, you need to ask Clever Cloud Support team to grant superuser permissions to your user. After that, you will be able to add additional users via Kibana.
 


### PR DESCRIPTION
## Describe your PR

_Summarize your changes here :   
Some client may want to use multiple auth method to connect to Kibana and not only their clever cloud account. For example to allow some of their external client to connect to it.
This PR give an example to allow to use both Authentification via clever cloud and Kibana authentification.


## Checklist

- [ ] My PR is related to an opened issue : #
- [ ] I've read the [contributing guidelines](/CleverCloud/documentation/blob/main/CONTRIBUTING.md)


## Reviewers
_Who should review these changes?_ @CleverCloud/reviewers

