### PR TITLE
chore: move glossary to tooltips and document it in README.md

### DIFF
--- a/.github/styles/config/vocabularies/Doc/accept.txt
+++ b/.github/styles/config/vocabularies/Doc/accept.txt
@@ -96,6 +96,8 @@ Symfony
 syslog
 TLS
 toolchain
+tooltip
+tooltips
 URIs
 VSCode
 WAF

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Example :
 {{< figure src="/images/changelog/console-new-ip-par.png" caption="The new IP shown in the console" width="800px">}}
 ```
 
+### Adding tooltips
+
+Tooltips are useful to provide additional information on terms or acronyms that may not be familiar to all readers. They help improve the accessibility and comprehension of your documentation without cluttering the main text.
+
+To create a tooltip, add the term and its associated tooltip definition in the [/data/tooltips.toml](/data/tooltips.toml) file. Once defined, tooltip automatically displays when users hover over associated terms in the documentation.
+
 ### Adding a new partial
 
 Partials are reusable content you can include in several pages. To use this feature:

--- a/data/tooltips.toml
+++ b/data/tooltips.toml
@@ -1,5 +1,5 @@
-iaas  = "Infrastructure as a Service"
-paas  = "Platform as a Service"
+IaaS  = "Infrastructure-as-a-Service"
+PaaS  = "Platform-as-a-Service"
 WAR   = "Web Archive"
 JEE   = "Java Enterprise Edition"
 EAR   = "Enterprise Archive"

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -3,10 +3,10 @@
 {{- errorf "missing tooltip title" -}}
 {{- end -}}
 {{ .Scratch.Set "title" $title }}
-{{ $def := index .Site.Data.glossary (.Scratch.Get "title")   }}
+{{ $def := index .Site.Data.tooltips (.Scratch.Get "title")   }}
 
 {{- if not $def -}}
-{{- errorf "%s not in glossary" $title  -}}
+{{- errorf "%s not in tooltips" $title  -}}
 {{- end -}}
 
 
@@ -15,7 +15,7 @@
     &lbrace;&lbrace; &lt; tooltip  title="{{$title}}" &gt; &rbrace;&rbrace;{{ .Inner }}&lbrace;&lbrace; &lt; /tooltip &gt; &rbrace;&rbrace;
   <hr />
 {{ end }}
-<a href="#" data-placement="top" data-animation="false" data-toggle="tooltip" title="{{ $def }}">{{ .Inner }}</a> 
+<a href="#" data-placement="top" data-animation="false" data-toggle="tooltip" title="{{ $def }}">{{ .Inner }}</a>
 {{ if $.Site.Params.Debug }}
 </div>
 {{ end }}


### PR DESCRIPTION
## Describe your PR

This PR documents tooltips shortcode in README and moves its file/name from `glossary` to `tooltip` which is more descriptive of what it's useful for. 