### PR TITLE
Fix ToC/llms.txt for partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,4 +179,4 @@ To create a tooltip, add the term and its associated tooltip definition in the [
 Partials are reusable content you can include in several pages. To use this feature:
 
 1. Create a new partial in `/layouts/shortcodes/content`
-2. Add it to the relevant pages like this: `{{< content "your-partial" >}}`
+2. Add it to the relevant pages like this: `{{% content "your-partial" %}}`

--- a/content/doc/account/create-account.md
+++ b/content/doc/account/create-account.md
@@ -14,4 +14,4 @@ aliases:
 - /doc/getting-started/authentication
 ---
 
-{{< content "authentication" >}}
+{{% content "authentication" %}}

--- a/content/doc/addons/jenkins.md
+++ b/content/doc/addons/jenkins.md
@@ -52,7 +52,7 @@ Refer to the [documentation](/developers/doc/cli/applications/) for more details
 Once you created your add-on, you should get to the dashboard. You should see a link named `Access Jenkins`. Opening that link will redirect you to our SSO
 authentication.
 
-{{< content "single-sign-on" >}}
+{{% content "single-sign-on" %}}
 
 ## Configure your Jenkins instance
 

--- a/content/doc/addons/materia-kv.md
+++ b/content/doc/addons/materia-kv.md
@@ -76,7 +76,7 @@ You can also deploy Materia KV add-ons with [Terraform provider](https://registr
 
 {{< /callout >}}
 
-{{< content "kv-explorer" >}}
+{{% content "kv-explorer" %}}
 
 ## Using the Redis API compatible layer
 

--- a/content/doc/addons/matomo.md
+++ b/content/doc/addons/matomo.md
@@ -71,7 +71,7 @@ Refer to the [Clever Tools documentation](/developers/doc/cli/addons/) for more 
 
 Once you created your add-on, open the management URL or use the `Access Matomo` link in the Matomo dashboard from the Console. To authenticate, you'll only need to use your Clever Cloud account.
 
-{{< content "single-sign-on" >}}
+{{% content "single-sign-on" %}}
 
 ## Configure your Matomo instance
 

--- a/content/doc/addons/mongodb.md
+++ b/content/doc/addons/mongodb.md
@@ -36,7 +36,7 @@ DEV plan is no longer available for MongoDB.
 
 Heavy usage of DEV databases may impact the shared cluster they rely upon. It will degrade performance of the other databases. To that extent, DEV plan has a limit of **15 operations/second**. Going above the limit might disconnect your database.
 
-{{< content "db-backup" >}}
+{{% content "db-backup" %}}
 
 ## Database Migration Process
 
@@ -56,7 +56,7 @@ The process consists in three steps:
 
 Encryption at rest is available on MongoDB. You can have more information on the [dedicated page]({{< ref "doc/administrate/encryption-at-rest.md" >}})
 
-{{< content "dbMigration" >}}
+{{% content "dbMigration" %}}
 
 ## Can I use Mongo Ops Manager on Clever Cloud?
 

--- a/content/doc/addons/mysql.md
+++ b/content/doc/addons/mysql.md
@@ -21,7 +21,7 @@ MySQL is available in regular versions and `early` for 8.4. That means it's the 
 
 {{< software_versions_shared_dedicated mysql>}}
 
-{{< content "db-backup" >}}
+{{% content "db-backup" %}}
 
 ## Migrating from an old database
 
@@ -34,7 +34,7 @@ If you want to import your **SQL** dump, you can use several methods:
 
 If you need to import a very large dump, contact [Clever Cloud Support](https://console.clever-cloud.com/ticket-center-choice).
 
-{{< content "dbMigration" >}}
+{{% content "dbMigration" %}}
 
 ## Direct access
 
@@ -52,7 +52,7 @@ Encryption at rest is available on MySQL. You can have more information on the [
 
 ## ProxySQL
 
-{{< content "proxysql" >}}
+{{% content "proxysql" %}}
 
 You can learn more about ProxySQL on the [dedicated documentation page]({{< ref "/guides/proxysql" >}})
 

--- a/content/doc/addons/postgresql.md
+++ b/content/doc/addons/postgresql.md
@@ -21,7 +21,7 @@ PostgreSQL is an object-relational database management system (ORDBMS) with an e
 
 {{< software_versions_shared_dedicated pg>}}
 
-{{< content "db-backup" >}}
+{{% content "db-backup" %}}
 
 ## Migrating from an old database
 
@@ -30,7 +30,7 @@ Some applications require a non-empty database to run properly. If you want to i
 2. Command line tool for PostgreSQL administration like `psql`
 3. Any PostgreSQL client such as [pgAdmin](https://www.pgadmin.org/)
 
-{{< content "dbMigration" >}}
+{{% content "dbMigration" %}}
 
 ## Replication
 
@@ -67,7 +67,7 @@ This referencing does not exist for dedicated databases.
 
 ## Pgpool-II
 
-{{< content "pgpool" >}}
+{{% content "pgpool" %}}
 
 You can learn more about Pgpool-II on the [dedicated documentation page]({{< ref "/guides/pgpool" >}})
 

--- a/content/doc/addons/redis.md
+++ b/content/doc/addons/redis.md
@@ -21,11 +21,11 @@ The version currently installed by the add-on are the following :
 
 {{< software_versions_shared_dedicated redis>}}
 
-{{< content "db-backup" >}}
+{{% content "db-backup" %}}
 
 A backup is a `tar.gz` archive containing both the `.rdb` and `.aof` files. You can extract this archive and run `redis-server` in the extracted folder to access data.
 
-{{< content "dbMigration" >}}
+{{% content "dbMigration" %}}
 
 ## Leader / follower topology
 
@@ -40,7 +40,7 @@ You can use Redis URI to connect to your databases with -u option. However, the 
 
 This is the correct syntax for `redis-cli` URI : *redis ://password@host:port[/database]*
 
-{{< content "kv-explorer" >}}
+{{% content "kv-explorer" %}}
 
 ## Default retention policy
 

--- a/content/doc/applications/docker.md
+++ b/content/doc/applications/docker.md
@@ -45,7 +45,7 @@ When you create a Docker application on Clever Cloud, the deployment process inv
    - The application starts in a Docker container and exposes the service on port 8080 by default.
    - If you need to expose your application on a different port, you can specify this using the environment variable `CC_DOCKER_EXPOSED_HTTP_PORT`.
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 ## Configure your Docker application
 
@@ -132,12 +132,12 @@ We provide a few examples of dockerized applications on Clever Cloud.
 You might need to use the `CC_DOCKERFILE = <name of your Dockerfile>` variable.
 
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/dotnet.md
+++ b/content/doc/applications/dotnet.md
@@ -26,9 +26,9 @@ You don't need to change a lot in your application, the *requirements* section e
   If you encounter an issue, please contact the support.
 {{< /callout >}}
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Dotnet application
 
@@ -145,14 +145,14 @@ Add the configuration file `nuget.config` :
 
 Set environment variables in the console according to your own information : `PACKAGE_REGISTRY_URI`, `PACKAGE_REGISTRY_USERNAME` and `PACKAGE_REGISTRY_PASSWORD`
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
 To access environment variables from your code, you can use `System.Environment.GetEnvironmentVariable("MY_VARIABLE")"`.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/elixir.md
+++ b/content/doc/applications/elixir.md
@@ -19,9 +19,9 @@ aliases:
 
 Clever Cloud supports Elixir based applications.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Elixir application
 
@@ -66,8 +66,8 @@ Finally, `mix phx.server` is invoked, and as always, you can override this behav
 
 Note: If you need to specify the timezone of your application, you can do it with the variable **TZ** set to the usual timezone format, for instance `Europe/Paris`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/doc/applications/frankenphp.md
+++ b/content/doc/applications/frankenphp.md
@@ -94,4 +94,4 @@ clever deploy # or clever restart if there is no code change
 
 FrankenPHP on Clever Cloud comes with a set included PHP extensions: `amqp`,`apcu`,`ast`,`bcmath`,`brotli`,`bz2`,`calendar`,`ctype`,`curl`,`dba`,`dom`,`exif`,`fileinfo`,`filter`,`ftp`,`gd`,`gmp`,`gettext`,`iconv`,`igbinary`,`imagick`,`intl`,`ldap`,`lz4`,`mbregex`,`mbstring`,`mysqli`,`mysqlnd`,`opcache`,`openssl`,`parallel`,`pcntl`,`pdo`,`pdo_mysql`,`pdo_pgsql`,`pdo_sqlite`,`pgsql`,`phar`,`posix`,`protobuf`,`readline`,`redis`,`session`,`shmop`,`simplexml`,`soap`,`sockets`,`sodium`,`sqlite3`,`ssh2`,`sysvmsg`,`sysvsem`,`sysvshm`,`tidy`,`tokenizer`,`xlswriter`,`xml`,`xmlreader`,`xmlwriter`,`xz`,`zip`,`zlib`,`yaml`,`zstd`
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/golang.md
+++ b/content/doc/applications/golang.md
@@ -19,9 +19,9 @@ aliases:
 
 Clever Cloud allows you to deploy any Go application. This page explains how to set up your project to run it on our service. You won't need to change a lot, the *requirements* will help you configure your applications with some mandatory files to add, and properties to set up.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Go application
 
@@ -131,17 +131,17 @@ build:
   Using `clevercloud/go.json` to define Makefile and binary paths is a deprecated method and should no longer be used.
 {{< /callout >}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with `PATH`: `os.Getenv("MY_VARIABLE")`.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}
 
 ## See also
 

--- a/content/doc/applications/haskell.md
+++ b/content/doc/applications/haskell.md
@@ -20,9 +20,9 @@ Haskell is a purely functional language, especially suited for robust web applic
 
 There are many ways to write web applications in Haskell, from raw [WAI](https://hackage.haskell.org/package/wai) to full-stack frameworks like [Yesod](https://www.yesodweb.com/), simple libraries like [scotty](https://hackage.haskell.org/package/scotty) or type-safe solutions like [servant](https://haskell-servant.GitHub.io/).
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Haskell application
 
@@ -120,8 +120,8 @@ You may have several packages in your application which can be time consuming wh
 CC_HASKELL_STACK_TARGET="mypackage"
 ```
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/doc/applications/java/java-gradle.md
+++ b/content/doc/applications/java/java-gradle.md
@@ -19,11 +19,11 @@ Gradle is a project automation tool that builds upon the concepts of Apache Ant 
 
 Note : like other runtimes, Java application need listen on `0.0.0.0:8080`
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
-{{< content "java-versions" >}}
+{{% content "java-versions" %}}
 
 Accepted values are the following:
 
@@ -117,10 +117,10 @@ Just create and commit the `gradlew` file and the wrapper `jar` and `properties`
   {{< /filetree/folder >}}
 {{< /filetree/container >}}
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/java/java-jar.md
+++ b/content/doc/applications/java/java-jar.md
@@ -17,11 +17,11 @@ Clever Cloud offers you to run any Java ARchive file. You do not need to change 
 
 Note : like other runtimes, Java application needs to listen on `0.0.0.0:8080`
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
-{{< content "java-versions" >}}
+{{% content "java-versions" %}}
 
 {{< runtimes_versions java >}}
 
@@ -105,7 +105,7 @@ You can use the following properties:
 | Optional | **deploy → goal**   | the goal/target and options you want to execute to deploy/run you project |
 | Required | **build → jarName** | jar file name of your application                                         |
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
 ## Custom run command
 
@@ -130,10 +130,10 @@ So, to use a variable, you just need `System.getProperties().getProperty("MY_VAR
 
 For Groovy applications, just use the `System.getProperty("MY_VARIABLE")`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/java/java-maven.md
+++ b/content/doc/applications/java/java-maven.md
@@ -28,9 +28,9 @@ Maven is essentially a project management and comprehension tool and as such pro
 * Releases
 * Distribution
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Java application
 
@@ -39,7 +39,7 @@ Maven is essentially a project management and comprehension tool and as such pro
 To run your app, you can, for example, use plugins like cargo ([Find it here](https://codehaus-cargo.github.io/cargo/Maven+3+Plugin.html)).
 Your application must be set to listen on the port 8080.
 
-{{< content "java-versions" >}}
+{{% content "java-versions" %}}
 
 {{< runtimes_versions java >}}
 
@@ -121,12 +121,12 @@ Example:
 CC_RUN_COMMAND="java -jar somefile.jar <options>"
 ```
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/java/java-war.md
+++ b/content/doc/applications/java/java-war.md
@@ -36,11 +36,11 @@ The supported containers are listed below:
 | Apache Tomcat 8.8 (TOMCAT8)   | Jetty 11.0.6 (JETTY11) | Payara 6.2023 (PAYARA6) | WildFly 27.0.1 (WILDFLY27) |
 | Apache Tomcat 10.0 (TOMCAT10) |                        |                         | WildFly 33.0.1 (WILDFLY33) |
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
-{{< content "java-versions" >}}
+{{% content "java-versions" %}}
 
 {{< runtimes_versions java >}}
 
@@ -156,7 +156,7 @@ Here's the list of the configuration values for the "container" field in `war.js
 | WILDFLY17  | Use Wildfly servlet container 17.x (see <https://wildfly.org/>)                              |     |
 | WILDFLY23  | Use Wildfly servlet container 23.x (see <https://wildfly.org/>)                              |     |
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}
 
 ## Custom run command
 
@@ -170,10 +170,10 @@ Example:
 CC_RUN_COMMAND="java -jar somefile.jar <options>"
 ```
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/doc/applications/linux.md
+++ b/content/doc/applications/linux.md
@@ -51,7 +51,7 @@ clever deploy # or clever restart if there is no code change
 
 ## Expand your toolbox with Mise package manager
 
-{{< content "mise" >}}
+{{% content "mise" %}}
 
 ### Mise configuration examples
 
@@ -59,5 +59,5 @@ clever deploy # or clever restart if there is no code change
 - [Deploy a Swift application with Mise](https://github.com/CleverCloud/swift-hello-world-example)
 - [Deploy a Zig application with Mise](https://github.com/CleverCloud/zig-with-mise-example)
 
-{{< content "redirectionio" >}}
-{{< content "varnish" >}}
+{{% content "redirectionio" %}}
+{{% content "varnish" %}}

--- a/content/doc/applications/meteor.md
+++ b/content/doc/applications/meteor.md
@@ -19,9 +19,9 @@ Clever Cloud allows you to deploy any Meteor.js application. This page will expl
 
 Be sure your `.meteor` folder is in your git repository.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Meteor.js based application
 
@@ -79,11 +79,11 @@ Add in the `scripts.start` field of the package.json: `node .build/bundle/main.j
 At each deployment, the needed Meteor.js version will be read from `.meteor/release` and installed.
 Your application will then be built using `meteor build --server-only` and deployed from the files created by this command.
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
 ### Oplog Tailing
 
@@ -97,6 +97,6 @@ Since Meteor 2.6.n the mongo driver detect the `MONGO_OPLOG_URL` by itself and y
 
 If you want to migrate from your classic node.js app to a meteor application, contact [Clever Cloud Support](https://console.clever-cloud.com/ticket-center-choice) with the application id.
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/nodejs.md
+++ b/content/doc/applications/nodejs.md
@@ -230,21 +230,21 @@ app.use(enforce.HTTPS({
 }));
 ```
 
-{{< content "new-relic" >}}
+{{% content "new-relic" %}}
 
 ## Troubleshooting your application
 
 If you are often experiencing auto restart of your Node.js instance, maybe you have an application crashing that we automatically restart.
 To target this behavior, you can gracefully shut down with events handlers on `uncaughtExeption` `unhandledRejection` `sigint` and `sigterm` and log at this moment, so you can fix the problem.
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
 To access environment variables from your code, you can use `process.env.MY_VARIABLE`.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/php.md
+++ b/content/doc/applications/php.md
@@ -22,9 +22,9 @@ into HTML.
 
 The HTTP server is [Apache 2](https://httpd.apache.org/), and the PHP code is executed by [PHP-FPM](https://php-fpm.org/).
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your PHP application
 
@@ -599,24 +599,24 @@ You can do this to fill them using the Authorization header:
 list($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']) = explode(':' , base64_decode(substr($_SERVER['Authorization'], 6)));
 ```
 
-{{< content "new-relic" >}}
+{{% content "new-relic" %}}
 
-{{< content "blackfire" >}}
+{{% content "blackfire" %}}
 
 ## Deploy on Clever Cloud
 
 Application deployment on Clever Cloud is via **Git or FTP**.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "deploy-ftp" >}}
+{{% content "deploy-ftp" %}}
 
 ## ProxySQL
 
-{{< content "proxysql" >}}
+{{% content "proxysql" %}}
 
 You can learn more about ProxySQL on the [dedicated documentation page]({{< ref "/guides/proxysql" >}} "ProxySQL")
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/python.md
+++ b/content/doc/applications/python.md
@@ -24,9 +24,9 @@ The default version of Python on Clever Cloud is the latest we support from bran
 
 {{< runtimes_versions python >}}
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Python application
 
@@ -78,7 +78,7 @@ psycopg2>=2.7 --no-binary psycopg2
 
 You can define a custom `requirements.txt` file with the environnement variable `CC_PIP_REQUIREMENTS_FILE` for example: `CC_PIP_REQUIREMENTS_FILE=config/production.txt`.
 
-{{< content "cached-dependencies" >}}
+{{% content "cached-dependencies" %}}
 
 ### Use setup.py
 
@@ -88,7 +88,7 @@ The goal will be launched after the dependencies from `requirements.txt` have be
 
 To execute a goal, you can define the [environment variable](#setting-up-environment-variables-on-clever-cloud) `PYTHON_SETUP_PY_GOAL="<your goal>"`.
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access [environment variables](#setting-up-environment-variables-on-clever-cloud) from your code, just get them from the environment with:
 
@@ -192,7 +192,7 @@ Whether you use uwsgi or gunicorn, you can enable the Gevent loop engine.
 
 To do so, add the `CC_PYTHON_USE_GEVENT` [environment variable](#setting-up-environment-variables-on-clever-cloud) to your application, with the `true` value.
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
 ## Celery apps
 
@@ -216,10 +216,10 @@ The `CC_PYTHON_CELERY_LOGFILE` path is relative to the application's path.
 There is a bug in versions <4.2 of Celery. You need to add the `CELERY_TIMEZONE = 'UTC'` environment variable. The bug is documented here: [https://GitHub.com/celery/celery/issues/4184](https://GitHub.com/celery/celery/issues/4184).
 {{< /callout >}}
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/ruby.md
+++ b/content/doc/applications/ruby.md
@@ -26,15 +26,15 @@ You do not need to change a lot in your application, the *requirements* will hel
 
 - [An example of Ruby on Rails application on Clever Cloud](https://GitHub.com/CleverCloudDemos/demo-rubyonrails-pg-rest)
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
-{{< content "language-specific-deploy/ruby" >}}
+{{% content "language-specific-deploy/ruby" %}}
 
-{{< content "new-relic" >}}
+{{% content "new-relic" %}}
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with `ENV["MY_VARIABLE"]`.
 
@@ -53,10 +53,10 @@ end
 
 It means you need to add `RAILS_LOG_TO_STDOUT=true` in your environment variables.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/rust.md
+++ b/content/doc/applications/rust.md
@@ -22,9 +22,9 @@ Rust is a system programming language that runs blazingly fast, prevents segfaul
 
 Clever Cloud allows you to deploy Rust web applications. This page will explain you how to set up your application to run it on our service.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Rust application
 
@@ -157,15 +157,15 @@ fn main() {
 
 This loads the environment variable in your `main` function and use `.expect` to fail early. This way, the application will refuse to start with an helpful error message if `MY_VAR` is not defined.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
 ### Deployment Video
 
 {{< youtube id="mz_8jzrM13Y" >}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}
 

--- a/content/doc/applications/scala.md
+++ b/content/doc/applications/scala.md
@@ -21,9 +21,9 @@ Clever Cloud allows you to deploy Scala (and Java) applications built with SBT. 
 
 If you're looking to deploy a [Play Framework](https://www.playframework.com) application, you can have a look at our dedicated [deployment guide for play framework applications]({{< ref "/guides/play-framework-2" >}})
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Scala application
 
@@ -90,16 +90,16 @@ If you're using
 application.secret=${APPLICATION_SECRET}
 ```
 
-{{< content "new-relic" >}}
+{{% content "new-relic" %}}
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with `System.getenv("MY_VARIABLE")`. Be aware that it can return null.
 
-{{< content "deploy-git" >}}
+{{% content "deploy-git" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/applications/static-apache.md
+++ b/content/doc/applications/static-apache.md
@@ -11,21 +11,21 @@ If you only need to serve static files without executing any code on the backend
 
 This runtime is based on apache, so shares a lot with the [PHP runtime]({{< ref "doc/applications/php" >}}). This means you can use `.htaccess` files for redirection or access control.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
 Application deployment on Clever Cloud is via **Git or FTP**.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
-{{< content "deploy-ftp" >}}
+{{% content "deploy-ftp" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
 ## Serving index.html for SPA (Single Page Application) routers
 

--- a/content/doc/applications/static.md
+++ b/content/doc/applications/static.md
@@ -114,5 +114,5 @@ Supported Static Site Generators (SSG) are:
 * Build command: `zola build --minify --output-dir <out-dir>`
 * Detected file: `config.toml`
 
-{{< content "redirectionio" >}}
-{{< content "varnish" >}}
+{{% content "redirectionio" %}}
+{{% content "varnish" %}}

--- a/content/doc/applications/v.md
+++ b/content/doc/applications/v.md
@@ -50,5 +50,5 @@ clever deploy # or clever restart if there is no code change
 
 - [Learn more about Clever Tasks](/developers/doc/develop/tasks/)
 
-{{< content "redirectionio" >}}
-{{< content "varnish" >}}
+{{% content "redirectionio" %}}
+{{% content "varnish" %}}

--- a/content/doc/ci-cd/custom-scripts.md
+++ b/content/doc/ci-cd/custom-scripts.md
@@ -48,7 +48,7 @@ before_script: # Download clever-tools before any script executes
   Using `before_script` in your GitLab pipeline affects your other scripts as well. Consider including it **in a separate job** if you run other test scripts unrelated to Clever Cloud deployments in your pipeline.
 {{< /callout >}}
 
-{{< content "ci-cd-configuration" >}}
+{{% content "ci-cd-configuration" %}}
 
 ## 🎓 Go further
 

--- a/content/doc/ci-cd/github.md
+++ b/content/doc/ci-cd/github.md
@@ -61,7 +61,7 @@ name: Create review app
 ```
 
 
-{{< content "ci-cd-configuration" >}}
+{{% content "ci-cd-configuration" %}}
 
 Full instructions are available on the [Action project](https://github.com/CleverCloud/clever-cloud-review-app).
 

--- a/content/doc/ci-cd/gitlab.md
+++ b/content/doc/ci-cd/gitlab.md
@@ -19,7 +19,7 @@ include:
   - component: $CI_SERVER_HOST/<CI_PROJECT_PATH>/<component-name>@~latest
 ```
 
-{{< content "ci-cd-configuration" >}}
+{{% content "ci-cd-configuration" %}}
 
 ### GitLab pipeline example
 

--- a/content/doc/develop/healthcheck.md
+++ b/content/doc/develop/healthcheck.md
@@ -10,4 +10,4 @@ keywords:
 - healthcheck
 ---
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/doc/develop/tasks.md
+++ b/content/doc/develop/tasks.md
@@ -110,8 +110,8 @@ clever env set --app TASK_APP_ID FILE_TO_PROCESS "https://mybucket.cellar-c2.ser
 clever restart --app TASK_APP_ID --quiet # That's if you don't care for the logs to show in here
 ```
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -108,13 +108,13 @@ Use these to define [commands to run]({{< ref "doc/develop/build-hooks.md" >}}) 
 |[`CC_VARNISH_STORAGE_SIZE`](../../administrate/cache "Cache") | Configure the size of the Varnish cache. | 1G |
 |[`CC_WORKER_COMMAND`](../../develop/workers "Workers") | Command to run in background as a worker process. You can run multiple workers. |  |
 
-{{< content "mise" >}}
+{{% content "mise" %}}
 
 | Name | Description |
 |-----------------|--------------------------|
 |`CC_RUN_MISE_INSTALL`| Set to `true` to run `mise install` before the build phase |
 
-{{< content "redirectionio" >}}
+{{% content "redirectionio" %}}
 >[!NOTE] Redirection.io is not available in Docker and PHP applications
 
 ### Tailscale support

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -138,7 +138,7 @@ If you're deploying from **GitHub**, your deployment should start automatically.
 
 ## Deploy a static Astro site using the CLI
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables
 
@@ -155,7 +155,7 @@ clever env set CC_PRE_BUILD_HOOK "npm install && npm run astro telemetry disable
 clever env set CC_POST_BUILD_HOOK "npm run build"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}
 
 ## Deploying an Astro Project with Server-Side Rendering (SSR)
 

--- a/content/guides/docusaurus.md
+++ b/content/guides/docusaurus.md
@@ -21,7 +21,7 @@ If you need an example source code, init a new project (you'll need [git](https:
 npx create-docusaurus@latest myStaticApp classic
 ```
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables
 Next, we configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
@@ -36,4 +36,4 @@ clever env set CC_PRE_BUILD_HOOK "npm install"
 clever env set CC_POST_BUILD_HOOK "npx docusaurus build"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}

--- a/content/guides/eleventy.md
+++ b/content/guides/eleventy.md
@@ -22,7 +22,7 @@ If you need an example source code, get [11ty base blog](https://github.com/11ty
 git clone https://github.com/11ty/eleventy-base-blog myStaticApp
 ```
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables
 Next, we configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
@@ -37,4 +37,4 @@ clever env set CC_PRE_BUILD_HOOK "npm install"
 clever env set CC_POST_BUILD_HOOK "npx @11ty/eleventy"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}

--- a/content/guides/fluentd.md
+++ b/content/guides/fluentd.md
@@ -28,9 +28,9 @@ Fluentd is an open source data collector written in Ruby, which lets you unify t
   Ruby application on Clever Cloud requires **Puma** webserver but fluentd is using **excon**.
 {{< /callout >}}
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 ## Configure your Fluentd + Docker application
 
@@ -136,10 +136,10 @@ RUN chmod +x go.sh
 CMD [ "/go.sh" ]
 ```
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/go-echoip.md
+++ b/content/guides/go-echoip.md
@@ -50,7 +50,7 @@ echoip/ ~ $ git commit -m "add clevercloud files" clevercloud/
 ```
 
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 
 
@@ -61,7 +61,7 @@ Your environment variable has been successfully saved
 ```
 
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
 
 

--- a/content/guides/hexo.md
+++ b/content/guides/hexo.md
@@ -26,7 +26,7 @@ For this project to work, don't import the theme with `git clone` but as a submo
 git submodule add https://github.com/probberechts/hexo-theme-cactus.git themes/cactus
 ```
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables
 Next, we configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
@@ -41,4 +41,4 @@ clever env set CC_PRE_BUILD_HOOK "npm i -g hexo && npm install"
 clever enc set CC_POST_BUILD_HOOK "hexo generate"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}

--- a/content/guides/hugo.md
+++ b/content/guides/hugo.md
@@ -22,7 +22,7 @@ If you need an example source code, use [Theme mini](https://github.com/nodejh/h
 git clone https://github.com/nodejh/hugo-theme-mini myStaticApp
 ```
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables and deploy script
 
@@ -53,7 +53,7 @@ tar xvf ${FILENAME} -C ${DEST_BIN}
 rm ${FILENAME}
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}
 
 ## 404 Redirections
 

--- a/content/guides/lume-deno.md
+++ b/content/guides/lume-deno.md
@@ -20,7 +20,7 @@ If you need an example source code, use [Lume website](https://github.com/lumela
 ```bash
 git clone https://github.com/lumeland/lume.land myStaticApp
 ```
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables and deploy script
 Next, configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
@@ -47,4 +47,4 @@ unzip ${FILENAME} -d ${DEST_BIN}
 rm ${FILENAME}
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}

--- a/content/guides/mdbook.md
+++ b/content/guides/mdbook.md
@@ -22,7 +22,7 @@ cargo install mdbook
 mdbook init myStaticApp --title="my mdBook" --ignore=git
 ```
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables
 Next, we configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
@@ -36,4 +36,4 @@ clever env set CC_PRE_BUILD_HOOK "cargo install mdbook"
 clever env set CC_POST_BUILD_HOOK "/home/bas/.cargo/bin/mdbook build"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}

--- a/content/guides/mkdocs.md
+++ b/content/guides/mkdocs.md
@@ -23,7 +23,7 @@ pip install mkdocs
 mkdocs new myStaticApp
 ```
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ## Configure environment variables
 Next, we configure the application with a medium build instance to quickly generate static files. The host instance is nano-sized, enough for a simple website. As Clever Cloud is based on standards, you only need to define a few variables:
@@ -37,4 +37,4 @@ clever env set CC_PRE_BUILD_HOOK "python3 -m ensurepip --upgrade && pip3 install
 clever env set CC_POST_BUILD_HOOK "mkdocs build"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}

--- a/content/guides/node-js-mongo-db.md
+++ b/content/guides/node-js-mongo-db.md
@@ -18,9 +18,9 @@ The application is a very simple todo list. You can add and delete values. More 
 
 * [GitHub repo](https://GitHub.com/CleverCloud/demo-nodejs-mongodb-rest)
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 ## Configure your Node.js + MongoDB application
 
@@ -28,14 +28,14 @@ The application is a very simple todo list. You can add and delete values. More 
 
 If you want to test easily a Node.js deployment on Clever Cloud, just clone the [GitHub repo](https://GitHub.com/CleverCloud/demo-nodejs-mongodb-rest).
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
 ## Configure your database
 
 Make sure you have created a MongoDB add-on in the Clever Cloud console, and that it's linked to your application. When it's done, you will be able to access all of your add-on [environment variables](#setting-up-environment-variables-on-clever-cloud) from the application.
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/nuxt.md
+++ b/content/guides/nuxt.md
@@ -36,7 +36,7 @@ git clone https://github.com/fayazara/zooper myStaticApp
 
 To deploy your Nuxt project to Clever Cloud, you need to **create a new application**.
 
-{{< content "language-specific-deploy/create-static" >}}
+{{% content "language-specific-deploy/create-static" %}}
 
 ### Configure environment variables
 
@@ -88,7 +88,7 @@ clever env set CC_PRE_BUILD_HOOK "npm run build"
 clever env set CC_RUN_COMMAND "node .output/server/index.mjs"
 ```
 
-{{< content "git-push" >}}
+{{% content "git-push" %}}
 
 ## Learn more
 

--- a/content/guides/pgpool.md
+++ b/content/guides/pgpool.md
@@ -26,7 +26,7 @@ Pgpool-II is not available on Docker instances. If you want to use Pgpool-II, yo
 
 ## What's Pgpool-II?
 
-{{< content "pgpool" >}}
+{{% content "pgpool" %}}
 
 ## Why use Pgpool-II?
 

--- a/content/guides/play-framework-1.md
+++ b/content/guides/play-framework-1.md
@@ -16,9 +16,9 @@ aliases:
 
 Clever Cloud supports Play 1.x applications natively. The present guide explains how to set up your application to run on Clever Cloud.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 ## Configure your Scala + Play! 1 application
 
@@ -61,16 +61,16 @@ More information on [playframework.com](https://www.playframework.com).
 
 HTTPS is handled by Clever Cloud ahead of your application, your application retrieves the traffic in plain http. To be able to use `request.secure`, you have to add `XForwardedSupport=all` in `application.conf`.
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access the environment variables from your code, you need to add `my.option=${MY_VARIABLE}` in your `application.conf` file, and then use the configuration item `my.option` in your application. e.g `%clevercloud.db.url="jdbc:mysql://"${MYSQL_ADDON_HOST}"/"${MYSQL_ADDON_DB}`
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/guides/play-framework-2.md
+++ b/content/guides/play-framework-2.md
@@ -18,9 +18,9 @@ aliases:
 
 Clever Cloud supports Play! 2 applications natively. The following guide explains how to set up your application to run on Clever Cloud.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 ## Configure your Scala + Play! 2 application
 
@@ -63,16 +63,16 @@ If you have a single repository with multiple modules, then you can specify whic
 For instance, if your Sbt project contains a `shared` and `play` module and you want to execute the `play` module, then add
 `CC_SBT_TARGET_DIR=play` environment variable.
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access the environment variables from your code, you need to add `my.option=${MY_VARIABLE}` in your `application.conf` file, and then use the configuration item `my.option` in your application. e.g `%clevercloud.db.url="jdbc:mysql://"${MYSQL_ADDON_HOST}"/"${MYSQL_ADDON_DB}`.
 You can also use the `System.getenv("MY_VARIABLE")` method. Be aware that it can return null.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
 ## Known problems with Play! 2
 
@@ -132,6 +132,6 @@ db.default.maxConnectionsPerPartition=5
 db.default.minConnectionsPerPartition=5
 ```
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
-{{< content "url_healthcheck" >}}
+{{% content "url_healthcheck" %}}

--- a/content/guides/proxysql.md
+++ b/content/guides/proxysql.md
@@ -26,7 +26,7 @@ your Dockerfile.
 
 ## What is ProxySQL
 
-{{< content "proxysql" >}}
+{{% content "proxysql" %}}
 
 ## When do I need ProxySQL
 

--- a/content/guides/python-django-sample.md
+++ b/content/guides/python-django-sample.md
@@ -17,9 +17,9 @@ aliases:
 The goal of this article is to show you how to deploy a Django application on Clever Cloud.
 The application is a very basic one. More information about the application in the[GitHub repo](https://github.com/CleverCloud/django-example).
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Django application
 
@@ -42,7 +42,7 @@ If you want to test easily a Django deployment on Clever Cloud, just clone the [
 
 You can find a lot more configuration options such as choosing python version and more on our dedicated [Python documentation]({{< ref "doc/applications/python" >}}).
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
 ### Manage.py tasks
 
@@ -58,7 +58,7 @@ Values must be separated by a comma:
 CC_PYTHON_MANAGE_TASKS="migrate, assets:precompile"
 ```
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with:
 
@@ -67,8 +67,8 @@ import os
 os.getenv("MY_VARIABLE")
 ```
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/ruby-on-rails.md
+++ b/content/guides/ruby-on-rails.md
@@ -20,20 +20,20 @@ You do not need to change a lot in your application, the *requirements* will hel
 
 - [An example of Ruby on Rails application on Clever Cloud](https://GitHub.com/CleverCloudDemos/demo-rubyonrails-pg-rest)
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
-{{< content "language-specific-deploy/ruby" >}}
+{{% content "language-specific-deploy/ruby" %}}
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with `ENV["MY_VARIABLE"]`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/ruby-rack-app-tutorial.md
+++ b/content/guides/ruby-rack-app-tutorial.md
@@ -106,16 +106,16 @@ You can now read [My application already exists](#my-application-already-exists)
 
 ### My application already exists
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with `ENV["MY_VARIABLE"]`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/ruby-rack.md
+++ b/content/guides/ruby-rack.md
@@ -16,9 +16,9 @@ aliases:
 Currently, Clever Cloud supports Rack-based applications.
 Created in 2007, Rack has become the de-facto standard for ruby web applications and is used in many frameworks such as Ruby on Rails.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
 ## Configure your Ruby and Rake application
 
@@ -35,14 +35,14 @@ Be sure that:
 
 - [An hello world tutorial of a Ruby and Rack application](/developers/guides/ruby-rack-app-tutorial)
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
 To access environment variables from your code, just get them from the environment with `ENV["MY_VARIABLE"]`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/tutorial-drupal.md
+++ b/content/guides/tutorial-drupal.md
@@ -16,21 +16,21 @@ aliases:
 
 [Drupal](https://new.drupal.org) applications almost work out of the box on Clever Cloud, you just have a few adjustments to make.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
-{{< content "new-relic" >}}
+{{% content "new-relic" %}}
 
-{{< content "env-injection" >}}
+{{% content "env-injection" %}}
 
-{{< content "link-addon" >}}
+{{% content "link-addon" %}}
 
 ## Configure your database
 
 Make sure you have created a MySQL database add-on in the Clever Cloud console, and that it's linked to your application. When it's done, you will be able to access all of your add-on environment variables from the application. You can use them as `DATABASE_URL=$MYSQL_ADDON_URI`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
 ### Git specific Drupal instructions
 
@@ -87,6 +87,6 @@ folder in which you create a `buckets.json` file).
 
 Do not forget the **/install.php** page otherwise installation will not happen.
 
-{{< content "deploy-ftp" >}}
+{{% content "deploy-ftp" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/tutorial-laravel.md
+++ b/content/guides/tutorial-laravel.md
@@ -164,7 +164,7 @@ return [
 
 This environment variable exists in any Clever Cloud instance. This configuration specifies to trust Clever Cloud proxies, allowing Laravel to seamlessly recognize HTTP requests in the presence of a proxyhugo server.
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}
 
 ## Go Further
 

--- a/content/guides/tutorial-symfony.md
+++ b/content/guides/tutorial-symfony.md
@@ -17,9 +17,9 @@ aliases:
 This tutorial assumes that your application is based on Symfony >= 3.4 and Symfony Flex.
 Symfony applications almost work out of the box on Clever Cloud, you just have a few adjustments to make.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
-{{< content "set-env-vars" >}}
+{{% content "set-env-vars" %}}
 
 ## Configure your Symfony application
 
@@ -90,11 +90,11 @@ For more information on configuring symfony behind a reverse proxy, you can read
 If everything looks fine and you still get 404 errors, remember that CleverCloud works with an Apache server, so you'll need an htaccess in the  `/public` directory.
 Symfony got your back on this: just run `composer require symfony/apache-pack`. See [the official documentation of Symfony](https://symfony.com/doc/current/setup/web_server_configuration.html) for more information.
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
- {{< content "env-injection" >}}
+ {{% content "env-injection" %}}
 
- {{< content "link-addon" >}}
+ {{% content "link-addon" %}}
 
 ## Configure your database
 
@@ -134,8 +134,8 @@ chmod +x clevercloud/post_build.sh
 
 Then, add this to the application's environment variables `CC_POST_BUILD_HOOK=./clevercloud/post_build.sh`.
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
-{{< content "deploy-ftp" >}}
+{{% content "deploy-ftp" %}}
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/content/guides/tutorial-wordpress.md
+++ b/content/guides/tutorial-wordpress.md
@@ -20,13 +20,13 @@ First, you could check [our global PHP documention](/developers/doc/deploy/appli
 
 This tutorial is mainly concerning a Git deployment. However, you can deploy using a classic FTP PHP app. Choose "FTP" when you create a new PHP app.
 
-{{< content "create-application" >}}
+{{% content "create-application" %}}
 
- {{< content "set-env-vars" >}}
+ {{% content "set-env-vars" %}}
 
- {{< content "deploy-git" >}}
+ {{% content "deploy-git" %}}
 
-{{< content "deploy-ftp" >}}
+{{% content "deploy-ftp" %}}
 
 ## Configure your WordPress application
 
@@ -186,14 +186,14 @@ define('WP_REDIS_PASSWORD', getenv('REDIS_PASSWORD'));
 
 Redis should now work with your WordPress.
 
- {{< content "new-relic" >}}
+ {{% content "new-relic" %}}
 
 ## Deploy WordPress the immutable way
 
 Discover a new way to deploy WordPress using Composer with Bedrock's boilerplate : [our tutorial on GitHub](https://github.com/CleverCloud/clever-wordpress)
 
-<!--  {{< content "env-injection" >}} -->
+<!--  {{% content "env-injection" %}} -->
 
-<!-- {{< content "link-addon" >}}-->
+<!-- {{% content "link-addon" %}}-->
 
-{{< content "more-config" >}}
+{{% content "more-config" %}}

--- a/layouts/partials/markdown/include_shortcode_content.md
+++ b/layouts/partials/markdown/include_shortcode_content.md
@@ -1,9 +1,8 @@
 {{- $content := . -}}
-{{- $patternSearch := "\\{\\{%\\s*content/([^%}]+)\\s*%\\}\\}" -}}
-{{- $patternClean := "\\{\\{%\\s*content/(.+?)\\s*%\\}\\}" -}}
+{{- $pattern := "\\{\\{%\\s*content\\s+\"(?P<name>[^\"]+)\"\\s*%\\}\\}" -}}
 
-{{- range $shortcodeFound := findRE $patternSearch $content -}}
-    {{- $name := replaceRE $patternClean "$1" $shortcodeFound -}}
+{{- range $shortcodeFound := findRE $pattern $content -}}
+    {{- $name := replaceRE $pattern "${name}" $shortcodeFound -}}
     {{- $filepath := printf "layouts/shortcodes/content/%s.md" $name -}}
     {{- with os.ReadFile $filepath -}}
         {{- $content = replace $content $shortcodeFound . -}}

--- a/layouts/shortcodes/content.html
+++ b/layouts/shortcodes/content.html
@@ -2,7 +2,7 @@
 {{- if $file -}}
   {{- $content := readFile (printf "layouts/shortcodes/content/%s.md" $file) -}}
   {{- if $content -}}
-    {{- $content | .Page.RenderString -}}
+    {{- $content -}}
   {{- else -}}
     {{- warnf "Content not found: %s" $file -}}
   {{- end -}}


### PR DESCRIPTION
## Describe your PR

We previously enhanced search results by modifying how partial content is integrated in documentation pages https://github.com/CleverCloud/documentation/pull/681

Since I've noticed downsides in ToC and `llms.txt` generation, as we replaced `{{% %}}` shortcode invocation with `{{< >}}`. So I looked for a way to go back on this without having bad results in search as we had before. 

This PR fixes this by: 
- Using `{{% %}}` 
- Updating content shortcode
- Updating markdown integration for llms.txt

You can notice it works by : 
- Looking at [V page](https://documentation-pr-710.cleverapps.io/developers/doc/applications/v/#use-redirectionio-as-a-proxy): Varnish/Redirection.io are present, mentioned in sidebar ToC
- Looking at [V llms.txt page](https://documentation-pr-710.cleverapps.io/developers/doc/applications/v/index.html.md): Varnish/Redirection.io are present
- Searching `bun` doesn't get results from healtcheck as we had before