### PR TITLE
Clean aliases

### DIFF
--- a/content/api/_index.md
+++ b/content/api/_index.md
@@ -7,7 +7,6 @@ draft: false
 aliases:
 - /doc/openapi
 - /doc/clever-cloud-apis/cc-api
-- /developers/doc/clever-cloud-apis/cc-api
 ---
 
 {{< hextra/hero-subtitle >}}

--- a/content/changelog/2024/12-24-terraform-0.5-Keycloak-Metabase.md
+++ b/content/changelog/2024/12-24-terraform-0.5-Keycloak-Metabase.md
@@ -13,7 +13,7 @@ authors:
     image: https://github.com/miton18.png?size=40
 description: Your favorite services as code
 aliases:
-- /developers/changelog/2024-12-24-terraform-0.5-Keycloak-Metabase.md
+- /changelog/2024-12-24-terraform-0.5-Keycloak-Metabase.md
 excludeSearch: true
 ---
 

--- a/content/doc/addons/_index.md
+++ b/content/doc/addons/_index.md
@@ -8,7 +8,6 @@ keywords:
 - deploy
 
 aliases:
-- /developers/doc/addons/clever-cloud-addons
 - /doc/addons/clever-cloud-addons
 - /doc/getting-started/dbaas
 type: "docs"

--- a/content/doc/addons/fs-bucket.md
+++ b/content/doc/addons/fs-bucket.md
@@ -12,7 +12,6 @@ keywords:
 - fs buckets
 - storage
 aliases:
-- /developers/doc/addons/fs_buckets
 - /doc/addons/fs_buckets
 - /doc/deploy/addon/fs-bucket
 type: docs

--- a/content/doc/administrate/apps-management.md
+++ b/content/doc/administrate/apps-management.md
@@ -12,7 +12,6 @@ keywords:
 - logs
 type: docs
 aliases:
-- /developers/doc/admin-console/apps-management
 - /doc/admin-console/apps-management
 ---
 

--- a/content/doc/administrate/cron.md
+++ b/content/doc/administrate/cron.md
@@ -12,7 +12,6 @@ tags:
 - administrate
 type: docs
 aliases:
-- /developers/doc/tools/crons
 - /doc/tools/crons
 ---
 

--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -15,7 +15,6 @@ keywords:
 - datadog
 - newrelic
 aliases:
-- /developers/doc/clever-cloud-apis/add-ons-log-collector
 - /doc/administrate/log-management/#get-continuous-logs-from-your-application
 - /doc/clever-cloud-apis/add-ons-log-collector
 type: docs

--- a/content/doc/applications/docker.md
+++ b/content/doc/applications/docker.md
@@ -10,7 +10,6 @@ str_replace_dict:
   "@application-type@": "Docker"
 type: docs
 aliases:
-- /developers/doc/docker/docker
 - /doc/deploy/application/docker
 - /doc/deploy/application/docker/docker
 - /doc/docker/docker

--- a/content/doc/applications/golang.md
+++ b/content/doc/applications/golang.md
@@ -11,7 +11,6 @@ str_replace_dict:
   "@application-type@": "Go"
 type: docs
 aliases:
-- /developers/doc/go/go
 - /doc/deploy/application/golang
 - /doc/deploy/application/golang/go
 - /doc/getting-started/by-language/go

--- a/content/doc/applications/ruby.md
+++ b/content/doc/applications/ruby.md
@@ -11,7 +11,6 @@ str_replace_dict:
   "@application-type@": "Ruby"
 type: docs
 aliases:
-- /developers/doc/ruby/ruby-on-rails
 - /doc/deploy/application/ruby
 - /doc/deploy/application/ruby/by-framework/ruby-on-rails
 - /doc/deploy/application/ruby/ruby-rack

--- a/content/doc/applications/rust.md
+++ b/content/doc/applications/rust.md
@@ -11,7 +11,6 @@ str_replace_dict:
   "@application-type@": "Rust"
 type: docs
 aliases:
-- /developers/doc/rust/rust
 - /doc/deploy/application/rust
 - /doc/deploy/application/rust/rust
 - /doc/getting-started/by-language/rust

--- a/content/doc/applications/scala.md
+++ b/content/doc/applications/scala.md
@@ -10,7 +10,6 @@ str_replace_dict:
   "@application-type@": "SBT + Scala"
 type: docs
 aliases:
-- /developers/doc/scala/scala
 - /doc/getting-started/by-language/scala
 - /doc/deploy/application/scala
 - /doc/deploy/application/scala/scala

--- a/content/doc/billing/analytics-consumption.md
+++ b/content/doc/billing/analytics-consumption.md
@@ -10,7 +10,6 @@ keywords:
 - consumption
 type: docs
 aliases:
-- /developers/doc/admin-console/analytics-consumption
 - /doc/admin-console/analytics-consumption
 ---
 

--- a/content/doc/billing/payments-invoicing.md
+++ b/content/doc/billing/payments-invoicing.md
@@ -15,7 +15,6 @@ keywords:
 - sepa
 type: docs
 aliases:
-- /developers/doc/admin-console/invoices-payments
 - /doc/admin-console/invoices-payments
 ---
 

--- a/content/doc/billing/unified-invoices.md
+++ b/content/doc/billing/unified-invoices.md
@@ -14,7 +14,6 @@ keywords:
 - payments
 type: docs
 aliases:
-- /developers/doc/clever-cloud-overview/unified-invoicing
 - /doc/clever-cloud-overview/unified-invoicing
 ---
 

--- a/content/doc/cli/_index.md
+++ b/content/doc/cli/_index.md
@@ -4,8 +4,6 @@ weight: 8
 title: Clever Tools (CLI)
 description: Use Clever Cloud CLI, Clever Tools
 aliases:
-- /developers/doc/clever-tools/getting_started
-- /developers/doc/cli/getting_started
 - /doc/administrate/clever-tools/getting_started
 - /doc/clever-tools/getting_started
 - /doc/cli/getting_started

--- a/content/doc/cli/applications/configuration.md
+++ b/content/doc/cli/applications/configuration.md
@@ -6,6 +6,7 @@ aliases:
 - /developers/doc/clever-tools/tcp-redirections
 - /developers/doc/cli/applications/deployment-lifecycle/applications-config
 - /developers/doc/cli/configure
+- /doc/cli/configure/
 - /doc/administrate/clever-tools/configure
 - /doc/clever-tools/tcp-redirections
 - /doc/cli/applications/deployment-lifecycle/applications-config

--- a/content/doc/cli/applications/configuration.md
+++ b/content/doc/cli/applications/configuration.md
@@ -3,13 +3,10 @@ type: docs
 title: Configuration
 description: Configure Clever Cloud applications with Clever Tools
 aliases:
-- /developers/doc/clever-tools/tcp-redirections
-- /developers/doc/cli/applications/deployment-lifecycle/applications-config
-- /developers/doc/cli/configure
-- /doc/cli/configure/
 - /doc/administrate/clever-tools/configure
 - /doc/clever-tools/tcp-redirections
 - /doc/cli/applications/deployment-lifecycle/applications-config
+- /doc/cli/configure
 ---
 
 A Clever Cloud application can easily be configured once created, through following commands. Each can target a specific application, adding `--app APP_ID_OR_NAME` or a local alias (`--alias`, `-a`).

--- a/content/doc/cli/applications/deployment-lifecycle.md
+++ b/content/doc/cli/applications/deployment-lifecycle.md
@@ -3,15 +3,12 @@ type: docs
 title: Deploy, Lifecycle
 description: Manage your application using the Clever Cloud CLI tool
 aliases:
-- /developers/doc/clever-tools/ssh-access
-- /developers/doc/cli/lifecycle
-- /developers/doc/cli/manage
-- /developers/doc/cli/ssh-access
 - /doc/administrate/clever-tools/lifecycle
 - /doc/administrate/clever-tools/manage
 - /doc/administrate/clever-tools/ssh-access
 - /doc/clever-tools/lifecycle
 - /doc/clever-tools/ssh-access
+- /doc/cli/lifecycle
 - /doc/cli/manage
 - /doc/cli/ssh-access
 ---

--- a/content/doc/cli/install/_index.md
+++ b/content/doc/cli/install/_index.md
@@ -4,7 +4,6 @@ weight: 1
 title: Install Clever Tools
 description: Getting started with Clever Cloud CLI
 aliases:
-- /developers/doc/cli-setup
 - /doc/cli-setup
 ---
 

--- a/content/doc/cli/notifications-webhooks.md
+++ b/content/doc/cli/notifications-webhooks.md
@@ -3,8 +3,7 @@ type: docs
 title: Notifications, WebHooks
 description: Configure Clever Cloud Nexus repository for you distribution
 aliases:
-- /developers/doc/cli/notifications
-- /developers/doc/reference/clever-tools/notifications
+- /doc/cli/notifications
 - /doc/administrate/clever-tools/notifications
 - /doc/reference/clever-tools/notifications
 ---

--- a/content/doc/quickstart.md
+++ b/content/doc/quickstart.md
@@ -8,7 +8,6 @@ keywords:
 - quickstart
 aliases:
 - /deploy
-- /developers/doc/getting-started/quickstart
 - /doc/getting-started/quickstart
 - /getting-started/quickstart
 type: "docs"

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -11,7 +11,6 @@ keywords:
 - env variables
 type: docs
 aliases:
-- /developers/doc/get-help/reference-environment-variables
 - /doc/get-help/reference-environment-variables
 ---
 

--- a/content/doc/zz_old_cli/notifications.md
+++ b/content/doc/zz_old_cli/notifications.md
@@ -15,7 +15,7 @@ keywords:
 - flowdock
 aliases:
 - /doc/administrate/clever-tools/notifications
-- /developers/doc/cli/notifications/
+- /doc/cli/notifications/
 draft: true
 ---
 

--- a/content/guides/play-framework-2.md
+++ b/content/guides/play-framework-2.md
@@ -11,8 +11,6 @@ keywords:
 str_replace_dict:
   "@application-type@": "Java or Scala + Play! 2"
 aliases:
-- /developers/doc/java/play-framework-2
-- /developers/doc/scala/play-framework-2
 - /doc/applications/java/play-framework-2
 - /doc/deploy/application/java/by-framework/play-framework-2
 - /doc/java/play-framework-2

--- a/content/guides/python-django-sample.md
+++ b/content/guides/python-django-sample.md
@@ -8,7 +8,6 @@ keywords:
 - python
 - django
 aliases:
-- /developers/doc/python/python-django-sample
 - /doc/deploy/application/python/tutorials/python-django-sample
 - /doc/python/python-django-sample
 type: docs

--- a/content/guides/tutorial-drupal.md
+++ b/content/guides/tutorial-drupal.md
@@ -10,7 +10,6 @@ keywords:
 str_replace_dict:
   "@application-type@": "PHP"
 aliases:
-- /developers/doc/php/tutorial-drupal
 - /doc/deploy/application/php/tutorials/tutorial-drupal
 - /doc/php/tutorial-drupal
 ---

--- a/content/guides/tutorial-symfony.md
+++ b/content/guides/tutorial-symfony.md
@@ -10,7 +10,6 @@ keywords:
 str_replace_dict:
   "@application-type@": "PHP"
 aliases:
-- /developers/doc/php/tutorial-symfony
 - /doc/deploy/application/php/tutorials/tutorial-symfony
 - /doc/php/tutorial-symfony
 ---

--- a/content/guides/tutorial-wordpress.md
+++ b/content/guides/tutorial-wordpress.md
@@ -10,7 +10,6 @@ keywords:
 str_replace_dict:
   "@application-type@": "PHP"
 aliases:
-- /developers/doc/php/tutorial-wordpress
 - /doc/deploy/application/php/tutorials/tutorial-wordpress
 - /doc/php/tutorial-wordpress
 ---


### PR DESCRIPTION
## Describe your PR

This PR cleans aliases, removing those starting with `/developers`

As stated [in Hugo documentation](https://gohugo.io/content-management/urls/#aliases):

> An alias with a leading slash is relative to the baseURL

Documentation base URL is `https://www.clever-cloud.com/developers`
