### PR TITLE
Add SSG guides section to static documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ You can include shared content in several pages. To use this feature:
 1. Create a new markdown file in `/shared`
 2. Add it to the relevant pages with: `{{% content "your-partial" %}}`
 
+> [!TIP]
+> If you need to include a shared content including shortcodes, use `{{% content-raw "your-partial" %}}` instead. Don't include headings (starting with `#`) in it as they won't be rendered in the page Table of Contents (ToC).
+
 ## Tooltips
 
 Tooltips are useful to provide additional information on terms or acronyms that may not be familiar to all readers. They help improve the accessibility and comprehension of your documentation without cluttering the main text.

--- a/content/doc/applications/static-apache.md
+++ b/content/doc/applications/static-apache.md
@@ -90,3 +90,6 @@ You can verify your configuration work using [this guide](https://docs.prerender
 If you set the `CC_WEBROOT = /<web-folder>` environment variable, make sure you put your `.htaccess` file at the root of your `/<web-folder>`. This is where Apache will look for directives when you deploy an application in a Static runtime.
 
 If you don't set the [`CC_WEBROOT`](/developers/doc/reference/reference-environment-variables/#php) environment variable, the root of your project is the root of your web server.
+
+## 🎓 Static Site Generators (SSG) guides
+{{% content-raw "static-guides" %}}

--- a/content/doc/applications/static.md
+++ b/content/doc/applications/static.md
@@ -117,5 +117,8 @@ Supported Static Site Generators (SSG) are:
 * Build command: `zola build --minify --output-dir <out-dir>`
 * Detected file: `config.toml`
 
+## 🎓 Static Site Generators (SSG) guides
+{{% content-raw "static-guides" %}}
+
 {{% content "redirectionio" %}}
 {{% content "varnish" %}}

--- a/layouts/shortcodes/content-raw.html
+++ b/layouts/shortcodes/content-raw.html
@@ -1,0 +1,9 @@
+{{- $file := .Get 0 -}}
+{{- if $file -}}
+  {{- $content := readFile (printf "shared/%s.md" $file) | safeHTML -}}
+  {{- if $content -}}
+    {{- .Page.RenderString $content -}}
+  {{- else -}}
+    {{- warnf "Content not found: %s" $file -}}
+  {{- end -}}
+{{- end -}}

--- a/shared/static-guides.md
+++ b/shared/static-guides.md
@@ -1,0 +1,11 @@
+{{< cards >}}
+  {{< card link="/developers/guides/astro" title="Astro" subtitle= "Build and deploy a Astro application on Clever Cloud" icon="astro" >}}
+  {{< card link="/developers/guides/docusaurus" title="Docusaurus" subtitle= "Build and deploy a static Docusaurus based website on Clever Cloud" icon="docusaurus" >}}
+  {{< card link="/developers/guides/eleventy" title="Eleventy (11ty)" subtitle= "Build and deploy a static Eleventy (11ty) based website on Clever Cloud" icon="11ty" >}}
+  {{< card link="/developers/guides/hexo" title="Hexo" subtitle= "Build and deploy a static Hexo based website on Clever Cloud" icon="hexo" >}}
+  {{< card link="/developers/guides/hugo" title="Hugo" subtitle= "Build and deploy a static Hugo based website on Clever Cloud" icon="hugo" >}}
+  {{< card link="/developers/guides/lume-deno" title="Lume (Deno)" subtitle= "Build and deploy a static Lume (Deno) based website on Clever Cloud" icon="deno" >}}
+  {{< card link="/developers/guides/mdbook" title="mdBook" subtitle= "Build and deploy a static mbBook based website on Clever Cloud" icon="mdbook" >}}
+  {{< card link="/developers/guides/mkdocs" title="MkDocs" subtitle= "Build and deploy a static MkDocs based website on Clever Cloud" icon="docs" >}}
+  {{< card link="/developers/guides/nuxt" title="Nuxt" subtitle= "Build and deploy a Nuxt application on Clever Cloud" icon="nuxt" >}}
+{{< /cards >}}


### PR DESCRIPTION
## Describe your PR

This PR adds a SSG Guides section to static documentation pages. It uses and documents a new `content-raw` shortcode, which handles shared content including shortcodes.