### PR TITLE
chore: move to clever.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This project is based on [Hugo](https://gohugo.io/) and uses [Hextra](https://im
 
 ## See deployed Documentation
 
-- [Home page](https://www.clever-cloud.com/developers/)
-- [Documentation](https://www.clever-cloud.com/developers/doc/)
-- [API Documentation](https://www.clever-cloud.com/developers/api/)
-- [Guides and Tutorials](https://www.clever-cloud.com/developers/guides/)
-- [Reference Clever Tools CLI](https://www.clever-cloud.com/developers/doc/reference/cli/)
-- [Reference Environment Variables](https://www.clever-cloud.com/developers/doc/reference/reference-environment-variables/)
-- [Clever Cloud Platform Changelog](https://www.clever-cloud.com/developers/changelog/)
+- [Home page](https://www.clever.cloud/developers/)
+- [Documentation](https://www.clever.cloud/developers/doc/)
+- [API Documentation](https://www.clever.cloud/developers/api/)
+- [Guides and Tutorials](https://www.clever.cloud/developers/guides/)
+- [Reference Clever Tools CLI](https://www.clever.cloud/developers/doc/reference/cli/)
+- [Reference Environment Variables](https://www.clever.cloud/developers/doc/reference/reference-environment-variables/)
+- [Clever Cloud Platform Changelog](https://www.clever.cloud/developers/changelog/)
 
 ## Quickstart
 
@@ -44,7 +44,7 @@ Find `server` command options in the [Hugo documentation](https://gohugo.io/comm
 
 ## Deploying on Clever Cloud
 
-As Clever Cloud [natively detects and build Hugo sites](https://www.clever-cloud.com/developers/doc/applications/static/), you just need some configuration to deploy this project:
+As Clever Cloud [natively detects and build Hugo sites](https://www.clever.cloud/developers/doc/applications/static/), you just need some configuration to deploy this project:
 
 ```bash
 # Declare what's the web server root, where to build the documentation
@@ -66,7 +66,7 @@ You can contribute by [creating an issue](https://github.com/CleverCloud/documen
 - [Contributing guidelines](./CONTRIBUTING.md)
 - [AI tools and LLMs instructions](./.cursorrules)
 
-Clever Cloud documentation is also available following the [llms.txt specification](https://www.clever-cloud.com/developers/llms.txt).
+Clever Cloud documentation is also available following the [llms.txt specification](https://www.clever.cloud/developers/llms.txt).
 
 ## Adding a new page or guide
 

--- a/content/changelog/2024/03-07-web-components-v13.md
+++ b/content/changelog/2024/03-07-web-components-v13.md
@@ -17,7 +17,7 @@ aliases:
 excludeSearch: true
 ---
 
-Clever Cloud's [Web Components](https://www.clever-cloud.com/developers/clever-components) v13 are available, with bug fixes, refactoring, and new features. We introduced new possibilities to highlight form fields (larger labels, with color), paving the way for our new add-on/application creation process.
+Clever Cloud's [Web Components](https://www.clever.cloud/developers/clever-components) v13 are available, with bug fixes, refactoring, and new features. We introduced new possibilities to highlight form fields (larger labels, with color), paving the way for our new add-on/application creation process.
 
 A standardized API is used for UI components that depend on a smart component. It includes a `state` property receiving state type: `loaded`, `loading`, `error` and data. Latest smart components no longer rely on `rxjs`, making them easier to maintain.
 

--- a/content/changelog/2025/03-07-rust-sdk-0.13.md
+++ b/content/changelog/2025/03-07-rust-sdk-0.13.md
@@ -15,4 +15,4 @@ description: New Auth solutions for your Rust applications
 excludeSearch: true
 ---
 
-[Rust SDK v0.13](https://github.com/CleverCloud/clevercloud-sdk-rust/releases/tag/v0.13.1) is available, uses Rust 1.85 and can now use [API tokens](https://www.clever-cloud.com/developers/api/howto/) or get credentials from [Clever Tools](https://github.com/CleverCloud/clever-tools/) configuration file if present in the system.
+[Rust SDK v0.13](https://github.com/CleverCloud/clevercloud-sdk-rust/releases/tag/v0.13.1) is available, uses Rust 1.85 and can now use [API tokens](/developers/api/howto/) or get credentials from [Clever Tools](https://github.com/CleverCloud/clever-tools/) configuration file if present in the system.

--- a/content/changelog/2025/05-06-images-update.md
+++ b/content/changelog/2025/05-06-images-update.md
@@ -26,7 +26,7 @@ We updated all our images. Deployment is in progress for all our users.
 * **Python:**
   * uv 0.7.2
 
-As previously announced, Python 3.8 [is not available in our images anymore](/developers/changelog/2025/03-25-python-3.8-eol/) and PHP 8.4 [is now used as default](https://www.clever-cloud.com/developers/changelog/2025/03-21-php-version-management-update/) for `CC_PHP_VERSION=8`. As Node.js 18 and Ruby 3.1 are now end-of-life, you'll get a warning if you use them.
+As previously announced, Python 3.8 [is not available in our images anymore](/developers/changelog/2025/03-25-python-3.8-eol/) and PHP 8.4 [is now used as default](/developers/changelog/2025/03-21-php-version-management-update/) for `CC_PHP_VERSION=8`. As Node.js 18 and Ruby 3.1 are now end-of-life, you'll get a warning if you use them.
 
 - [Learn more about Node.js release cycle](https://nodejs.org/en/about/releases/)
 - [Learn more about PHP release cycle](https://www.php.net/supported-versions.php)

--- a/content/changelog/2025/05-28-oauth-consumer-new-interface.md
+++ b/content/changelog/2025/05-28-oauth-consumer-new-interface.md
@@ -15,8 +15,8 @@ description: You like new pages? Wait for the next one!
 excludeSearch: true
 ---
 
-A new interface is available [in Clever Cloud Console to create](https://console.clever-cloud.com/users/me/oauth-consumers/new) and manage OAuth consumers. It's better, clearer, simpler, and uses our open source [web components](https://www.clever-cloud.com/developers/clever-components).
+A new interface is available [in Clever Cloud Console to create](https://console.clever-cloud.com/users/me/oauth-consumers/new) and manage OAuth consumers. It's better, clearer, simpler, and uses our open source [web components](/developers/clever-components).
 
-- [Learn more about OAuth consumers](https://www.clever-cloud.com/developers/api/howto/#oauth1)
+- [Learn more about OAuth consumers](/developers/api/howto/#oauth1)
 
 ![New OAuth consumers interface](/images/new-oauth-consumer.webp)

--- a/content/changelog/2025/06-05-api-tokens-console-tips.md
+++ b/content/changelog/2025/06-05-api-tokens-console-tips.md
@@ -32,6 +32,6 @@ If you created your Clever Cloud account through the GitHub integration, you'll 
 
 ## Clever Tools and API tips in the Console
 
-This interface also introduces a new [Web Component](https://www.clever-cloud.com/developers/clever-components) to show Clever Tools commands and API requests related to the page you visit. In the coming weeks, we'll add more of these tips over the Clever Cloud Console.
+This interface also introduces a new [Web Component](https://www.clever.cloud/developers/clever-components) to show Clever Tools commands and API requests related to the page you visit. In the coming weeks, we'll add more of these tips over the Clever Cloud Console.
 
 ![API Tokens API & Clever Tools Tips](/images/console-api-tokens-tips.webp)

--- a/content/changelog/2025/06-05-oauth-tokens-new-interface.md
+++ b/content/changelog/2025/06-05-oauth-tokens-new-interface.md
@@ -19,6 +19,6 @@ After [renewing OAuth consumers management](/developers/changelog/2025/05-28-oau
 
 We also added a link to Clever Cloud's OAuth tokens documentation.
 
-- [Learn more about OAuth tokens](https://www.clever-cloud.com/developers/api/howto/#oauth1)
+- [Learn more about OAuth tokens](/api/howto/#oauth1)
 
 ![New OAuth tokens interface](/images/console-new-oauth-tokens.webp)

--- a/content/changelog/2025/07-02-terraform-0.10.md
+++ b/content/changelog/2025/07-02-terraform-0.10.md
@@ -15,6 +15,6 @@ authors:
 excludeSearch: true
 ---
 
-The [0.10.0 release](https://github.com/CleverCloud/terraform-provider-clevercloud/releases/tag/v0.10.0) of the Clever Cloud Terraform provider is available. It fixes some bugs, introduces support for [Network Groups](/developers/doc/develop/network-groups/) and [Pulsar](https://www.clever-cloud.com/developers/doc/addons/pulsar/). You can set a version for a [PostgreSQL add-on](/developers/doc/addons/postgresql/).
+The [0.10.0 release](https://github.com/CleverCloud/terraform-provider-clevercloud/releases/tag/v0.10.0) of the Clever Cloud Terraform provider is available. It fixes some bugs, introduces support for [Network Groups](/developers/doc/develop/network-groups/) and [Pulsar](/developers/doc/addons/pulsar/). You can set a version for a [PostgreSQL add-on](/developers/doc/addons/postgresql/).
 
 * Learn more about [our Terraform provider](https://registry.terraform.io/providers/CleverCloud/clevercloud/latest/docs)

--- a/content/doc/addons/cellar.md
+++ b/content/doc/addons/cellar.md
@@ -639,7 +639,7 @@ When versioning is enabled, the newly added object is automatically provided wit
 
   {{< tab >}}
 
-  The following command assumes you have configured your AWS CLI and added an alias as shown earlier in the section [Creating a bucket with AWS CLI](https://www.clever-cloud.com/developers/doc/addons/cellar/#with-aws-cli)
+  The following command assumes you have configured your AWS CLI and added an alias as shown earlier in the section [Creating a bucket with AWS CLI](/developers/doc/addons/cellar/#with-aws-cli)
 
   ### Activate versioning with AWS CLI
 

--- a/content/doc/addons/otoroshi.md
+++ b/content/doc/addons/otoroshi.md
@@ -51,7 +51,7 @@ An initial account has been created, change the password at first login (Securit
  - Admin user name: cc-account-admin
  - Temporary password: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-Learn more about Otoroshi with LLM on Clever Cloud: https://www.clever-cloud.com/developers/doc/addons/otoroshi/
+Learn more about Otoroshi with LLM on Clever Cloud: https://www.clever.cloud/developers/doc/addons/otoroshi/
 ```
 
 Refer to the [Clever Tools documentation](/developers/doc/cli/addons/) for more details on add-on management.

--- a/content/doc/applications/php.md
+++ b/content/doc/applications/php.md
@@ -71,7 +71,7 @@ If you put the `.user.ini` file in a subdirectory; settings will be applied recu
 
 However, some PHP applications may want to check for the PHP-FPM configuration pre-requisites, `post_max_size` or `upload_max_filesize` values for example.
 
-To load the PHP-FPM `.user.ini` file during a PHP-CLI process, in a [hook](https://www.clever-cloud.com/developers/doc/develop/build-hooks/), use the `PHP_INI_SCAN_DIR` environment variable to load the additional file.
+To load the PHP-FPM `.user.ini` file during a PHP-CLI process, in a [hook](/developers/doc/develop/build-hooks/), use the `PHP_INI_SCAN_DIR` environment variable to load the additional file.
 
 Assuming the script runs at the root-folder of the application:
 

--- a/content/doc/applications/static.md
+++ b/content/doc/applications/static.md
@@ -13,7 +13,7 @@ aliases:
 
 ## Overview
 
-Static is a flexible, light and simple runtime dedicated to static sites generators (SSG), designed for minimum configuration effort with Auto-build feature. Pico instances are available, it allows users to put services in front of it, such as [Redirection.io](https://www.clever-cloud.com/developers/doc/reference/reference-environment-variables/#use-redirectionio-as-a-proxy) or [Varnish](/developers/doc/administrate/cache/).
+Static is a flexible, light and simple runtime dedicated to static sites generators (SSG), designed for minimum configuration effort with Auto-build feature. Pico instances are available, it allows users to put services in front of it, such as [Redirection.io](/developers/doc/reference/reference-environment-variables/#use-redirectionio-as-a-proxy) or [Varnish](/developers/doc/administrate/cache/).
 
 > [!NOTE] Static is a new runtime
 > Help us to improve it by reporting any issue or suggestion on the [Clever Cloud Community](https://github.com/CleverCloud/Community/discussions/categories/paas-runtimes)

--- a/content/doc/best-practices/tips_and_tricks.md
+++ b/content/doc/best-practices/tips_and_tricks.md
@@ -351,7 +351,7 @@ Available through:
 
 - [npm package](https://www.npmjs.com/package/@clevercloud/components)
 - [Public repository](https://github.com/CleverCloud/clever-components)
-- [Storybook documentation](https://www.clever-cloud.com/developers/clever-components)
+- [Storybook documentation](https://www.clever.cloud/developers/clever-components)
 
 ### Custom Solutions
 

--- a/content/doc/reference/cli.md
+++ b/content/doc/reference/cli.md
@@ -2206,5 +2206,5 @@ Usage: remove NOTIFICATION-ID
 
 ## Clever Cloud complete documentation
 
-For more comprehensive information about Clever Cloud, read the complete documentation: https://www.clever-cloud.com/developers/doc/
-Clever Cloud complete documentation is available in a LLM-optimized format: https://www.clever-cloud.com/developers/llms.txt
+For more comprehensive information about Clever Cloud, read the complete documentation: https://www.clever.cloud/developers/doc/
+Clever Cloud complete documentation is available in a LLM-optimized format: https://www.clever.cloud/developers/llms.txt

--- a/content/guides/otree.md
+++ b/content/guides/otree.md
@@ -32,7 +32,7 @@ You can create an application in the [Console](https://console.clever-cloud.com)
 
 ```bash
 # Install Clever Tools if you don't have it yet
-# You can also use your package manager: https://www.clever-cloud.com/developers/doc/cli/install/
+# You can also use your package manager: https://www.clever.cloud/developers/doc/cli/install/
 npm i -g clever-tools
 clever login
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://www.clever-cloud.com/developers
+baseURL: https://www.clever.cloud/developers
 title: Clever Cloud Documentation
 publishDir: public/developers
 
@@ -49,7 +49,7 @@ menu:
       weight: 4
     - identifier: components
       name: Web Components
-      url: https://www.clever-cloud.com/developers/clever-components
+      url: https://www.clever.cloud/developers/clever-components
       weight: 5
     - name: Search
       weight: 6


### PR DESCRIPTION
## Describe your PR

This PR:
- moves documentation domain to `clever.cloud` in Hugo config
- updates links to `clever.cloud` when needed
- updates other links to relative form