### PR TITLE
Hextra 0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/CleverCloud/documentation
 
-go 1.24.0
+go 1.25.0
 
-require github.com/imfing/hextra v0.10.2 // indirect
+require github.com/imfing/hextra v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/imfing/hextra v0.10.2 h1:etVtBSHH3V4xYZ2uqlh7HWZitdaZLWG+sCoGtFqyAEk=
-github.com/imfing/hextra v0.10.2/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=
+github.com/imfing/hextra v0.11.0 h1:2HswtfKD/TFg2VWp0hvsH5F3/WoEugiz8s3n2JFouqY=
+github.com/imfing/hextra v0.11.0/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -135,7 +135,7 @@ params:
       displayPagination: true
 
   description: Clever Cloud is a Platform-as-a-Service (PaaS) cloud provider, an automated hosting platform for developers. Deploy your app easily and launch dependencies without having to worry about the infrastructure set up.
-
+  
   displayUpdatedDate: true
   dateFormat: January 2, 2006
 
@@ -143,6 +143,8 @@ params:
     enable: true
     base: https://github.com/CleverCloud/documentation/edit/main/content/
 
+  externalLinkDecoration: true
+  
   footer:
     enable: false
     displayCopyright: false

--- a/layouts/changelog/single.html
+++ b/layouts/changelog/single.html
@@ -4,7 +4,7 @@
     {{ partial "toc.html" . }}
     <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]">
       <main class="hx:w-full hx:min-w-0 hx:max-w-6xl hx:px-6 hx:pt-4 hx:md:px-12">
-        {{ partial "breadcrumb.html" . }}
+        {{ partial "breadcrumb.html" (dict "page" . "enable" true) }}
         {{ if .Title }}<h1 class="hx:mt-2 hx:text-4xl hx:font-bold hx:tracking-tight hx:text-slate-900 hx:dark:text-slate-100">{{ .Title }}</h1>{{ end }}
         <div class="hx:mt-4 hx:mb-16 hx:text-gray-500 hx:dark:text-gray-400 hx:text-sm hx:flex hx:items-center hx:flex-wrap hx:gap-y-2">
           {{- with $date := .Date }}<span class="hx:mr-1">{{ partial "utils/format-date" $date }}</span>{{ end -}}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -4,7 +4,7 @@
     {{ partial "toc.html" . }}
     <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]">
       <main class="hx:w-full hx:min-w-0 hx:max-w-6xl hx:px-6 hx:pt-4 hx:md:px-12">
-        {{ partial "breadcrumb.html" . }}
+        {{ partial "breadcrumb.html" (dict "page" . "enable" true) }}
         <div class="content">
           {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
           {{ .Content }}

--- a/layouts/openapi/baseof.html
+++ b/layouts/openapi/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}">
+<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default `ltr` }}">
 
 <head>
   <meta charset="utf-8" />
@@ -19,7 +19,8 @@
     {{ .Site.Title -}}
     {{ end -}}
   </title>
-  
+  <meta name="description" content="{{ partial "utils/page-description.html" . }}" />
+
   {{- with .Params.canonical -}}
   <link rel="canonical" href="{{ . }}" itemprop="url" />
   {{- else -}}
@@ -64,32 +65,32 @@
   <link rel="stylesheet" href="{{ $cssUrl }}" />
   {{ end }}
 
-  <!-- Google Analytics -->
-  {{- if and hugo.IsProduction .Site.Config.Services.GoogleAnalytics.ID }}
-  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
-  {{ partial "google-analytics.html" . -}}
-  {{- end }}
+  {{ partial "components/analytics/analytics.html" . }}
 
   <script>
-    /* Initialize light/dark mode */
-    const defaultTheme = '{{ site.Params.theme.default | default `system`}}';
+    // The section must not be in the theme.js file because it can create a quick flash (switch between light and dark).
 
-    const setDarkTheme = () => {
-      document.documentElement.classList.add("dark");
-      document.documentElement.style.colorScheme = "dark";
-    }
-    const setLightTheme = () => {
-      document.documentElement.classList.remove("dark");
-      document.documentElement.style.colorScheme = "light";
-    }
+    function setTheme(theme) {
+      document.documentElement.classList.remove("light", "dark");
 
-    if ("color-theme" in localStorage) {
-      localStorage.getItem("color-theme") === "dark" ? setDarkTheme() : setLightTheme();
-    } else {
-      defaultTheme === "dark" ? setDarkTheme() : setLightTheme();
-      if (defaultTheme === "system") {
-        window.matchMedia("(prefers-color-scheme: dark)").matches ? setDarkTheme() : setLightTheme();
+      if (theme !== "light" && theme !== "dark") {
+        theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
       }
+
+      document.documentElement.classList.add(theme);
+      document.documentElement.style.colorScheme = theme;
+    }
+
+    setTheme("color-theme" in localStorage ? localStorage.getItem("color-theme") : '{{ site.Params.theme.default | default `system`}}')
+
+  </script>
+
+  <script>
+    // The section must not be in the banner.js file because it can create a quick flash.
+
+    if (localStorage.getItem('{{ site.Params.banner.key | default `banner-closed` }}')) {
+      document.documentElement.style.setProperty("--hextra-banner-height", "0px");
+      document.documentElement.classList.add("hextra-banner-hidden");
     }
   </script>
 
@@ -106,7 +107,7 @@
   {{ partial "custom/head-end.html" . -}}
 </head>
 
-<body dir="{{ .Site.Language.LanguageDirection | default `ltr` }}">
+<body>
   {{- partial "navbar.html" . -}}
   {{- block "main" . }}{{ end -}}
   {{- if or (eq .Site.Params.footer.enable nil) (.Site.Params.footer.enable) }}


### PR DESCRIPTION
## 📝 What does this PR do?

This PR updates Hextra themes to [0.11 release](https://imfing.github.io/hextra/versions/latest/blog/v0.11/). There's only 1 breaking change for us, on breadcrumbs management. I've updated layouts needing it. And also OpenAPI layouts to reproduce upstream changes.

There are lots of new features in this release we could explore in upcoming PRs.

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [ ] 📚 Documentation update
- [ ] ✨ New content/feature
- [x] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors
