### PR TITLE
chore: use Hugo 0.150

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -273,7 +273,7 @@ The site is configured for Clever Cloud hosting with the `static` runtime and th
 - `CC_WEBROOT="public"`
 - `CC_STATIC_AUTOBUILD_OUTDIR="public/developers"`
 - `SERVER_ERROR_PAGE_404="developers/404.html"`
-- Optional: `CC_HUGO_VERSION="0.148"` to specify Hugo version (example value)
+- Optional: `CC_HUGO_VERSION="0.150"` to specify Hugo version (example value)
 
 ## Quality Assurance Requirements
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           ORGA_ID: ${{ secrets.ORGA_ID }}
-          GH_CC_HUGO_VERSION: 0.149
+          GH_CC_HUGO_VERSION: 0.150
           GH_CC_STATIC_AUTOBUILD_OUTDIR: public/developers
           GH_CC_WEBROOT: public
           GH_SERVER_ERROR_PAGE_404: developers/404.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ The site is configured for Clever Cloud hosting with the `static` runtime and th
 - `CC_WEBROOT="public"`
 - `CC_STATIC_AUTOBUILD_OUTDIR="public/developers"`
 - `SERVER_ERROR_PAGE_404="developers/404.html"`
-- Optional: `CC_HUGO_VERSION="0.149"` to specify Hugo version (example value)
+- Optional: `CC_HUGO_VERSION="0.150"` to specify Hugo version (example value)
 
 ## Data Management
 Runtime versions and software compatibility information is maintained in `/data/runtime_versions.yml` and should be kept current with platform capabilities. The site generates various output formats including standard HTML and a special LLMS output format at `/llms.txt` for AI consumption.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ SERVER_ERROR_PAGE_404="developers/404.html"
 ```
 
 > [!TIP]
-> You can set the Hugo version with `CC_HUGO_VERSION` with a value like `0.149`
+> You can set the Hugo version with `CC_HUGO_VERSION` with a value like `0.150`
 
 ## Contributing
 


### PR DESCRIPTION
## 📝 What does this PR do?

This PR moves Hugo version to 0.150 for CI, deployment instructions

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [ ] 📚 Documentation update
- [ ] ✨ New content/feature
- [x] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

