### PR TITLE
 docs: add note on custom configuration callout to Add-ons index page

### DIFF
--- a/content/doc/addons/_index.md
+++ b/content/doc/addons/_index.md
@@ -24,6 +24,12 @@ aliases:
 
 Connect your application to an add-on:
 
+{{< callout type="info" >}}
+**Need a custom configuration?** Some add-ons support custom setups that may not be listed in their specific documentation pages (custom parameters, specific versions, advanced tuning, cluster configurations, etc.). 
+
+To discuss your specific requirements and check what's possible, please [contact our support team](https://console.clever-cloud.com/ticket-center-choice).
+{{< /callout >}}
+
 ## Databases
 
 {{< cards >}}


### PR DESCRIPTION
## 📝 What does this PR do?

Add an info callout informing users they can contact support to request custom add-on configurations not documented in individual add-on pages.


## 🔗 Related Issue (if applicable)

- Closes #
- Related to #

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers

---

<details>
<summary>📋 <strong>For major changes</strong> (click to expand)</summary>

### Additional testing performed
_Describe any specific testing done for complex changes_

### Screenshots
_Add screenshots for visual/layout changes_

### Breaking changes
_List any breaking changes or migration notes_

</details>

