### PR TITLE
changelog: Kubernetes 1.36 by default

### DIFF
--- a/content/changelog/2026/05-05-kubernetes-1.36-default.md
+++ b/content/changelog/2026/05-05-kubernetes-1.36-default.md
@@ -1,0 +1,33 @@
+---
+title: Kubernetes 1.36 is now used by default
+description: Kubernetes 1.36 is now the default version for new clusters on Clever Kubernetes Engine
+date: 2026-05-05
+tags:
+  - kubernetes
+  - release
+authors:
+  - name: Gilles Biannic
+    link: https://github.com/GillesBIANNIC
+    image: https://github.com/GillesBIANNIC.png?size=40
+  - name: David Legrand
+    link: https://github.com/davlgd
+    image: https://github.com/davlgd.png?size=40
+excludeSearch: true
+---
+
+Kubernetes 1.36 "Haru" is available on Clever Kubernetes Engine [since its release](/changelog/2026/04-24-kubernetes-1.36/). It's now the default version deployed when no `--cluster-version` is specified. New clusters will run on v1.36 unless you explicitly pick another supported one.
+
+You can still target v1.35 or v1.34 with `--cluster-version`, as long as they remain supported (n-2 from the current release, mirroring the official Kubernetes support policy):
+
+```bash
+clever k8s create myCluster --cluster-version 1.35
+```
+
+Existing clusters are not migrated automatically. To move one to v1.36, use [Clever Tools](/doc/cli/kubernetes/):
+
+```bash
+clever k8s version update myClusterNameOrId 1.36
+```
+
+- [Learn more about Kubernetes 1.36](/changelog/2026/04-24-kubernetes-1.36/)
+- [Learn more about Kubernetes on Clever Cloud](/doc/kubernetes/)

--- a/content/doc/kubernetes/_index.md
+++ b/content/doc/kubernetes/_index.md
@@ -285,8 +285,8 @@ example-nodegroup   2                  2                  M        Synced   2m
 kubectl get nodes
 
 NAME                      STATUS   ROLES    AGE     VERSION
-example-nodegroup-node0   Ready    <none>   6d17h   v1.35.4
-example-nodegroup-node1   Ready    <none>   3d18h   v1.35.4
+example-nodegroup-node0   Ready    <none>   6d17h   v1.36.0
+example-nodegroup-node1   Ready    <none>   3d18h   v1.36.0
 ```
 
 `DESIREDNODECOUNT` is the number of nodes you asked for, `CURRENTNODECOUNT` is the number of nodes currently in the node group. When creating a node group, `CURRENTNODECOUNT` starts at `0` and increases until it reaches `DESIREDNODECOUNT`.

--- a/data/kubernetes_versions.yml
+++ b/data/kubernetes_versions.yml
@@ -3,7 +3,7 @@
 # Update this file when a new Kubernetes version becomes available or when the
 # platform default rolls forward.
 current: "1.36"
-default: "1.35"
+default: "1.36"
 supported:
   - "1.36"
   - "1.35"


### PR DESCRIPTION
## 📝 What does this PR do?

This PR adds an entry about Kubernetes 1.36 now used by default 

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [x] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors