### PR TITLE
Add ReplicaSet configuration notice to MongoDB documentation

### DIFF
--- a/content/doc/addons/mongodb.md
+++ b/content/doc/addons/mongodb.md
@@ -62,6 +62,14 @@ Encryption at rest is available on MongoDB. You can have more information on the
 
 {{% content "db-migration" %}}
 
+## ReplicaSet Configuration
+
+{{< callout type="info" >}}
+**Need a ReplicaSet setup?** Clever Cloud supports switching your MongoDB add-on to a ReplicaSet configuration (single-node) for features like change streams, transactions, or oplog access.
+
+To discuss your requirements and enable ReplicaSet on your add-on, please [contact our support team](https://console.clever-cloud.com/ticket-center-choice).
+{{< /callout >}}
+
 ## Can I use Mongo Ops Manager on Clever Cloud?
 
 To be able to use [Mongo Ops Manager](https://www.mongodb.com/products/ops-manager), you'll need a valid MongoDB Enterprise Advanced subscription and to deploy a [Linux version of their manager solution](https://www.mongodb.com/try/download/ops-manager). If you haven't purchased any license from MongoDB and you are using the Community version, you might be looking for a similar service for your databases.


### PR DESCRIPTION
## 📝 What does this PR do?

Add an info callout informing users they can contact support to switch their MongoDB add-on to a single-node ReplicaSet configuration.


## 🔗 Related Issue (if applicable)

- Closes #
- Related to #

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers

---

<details>
<summary>📋 <strong>For major changes</strong> (click to expand)</summary>

### Additional testing performed
_Describe any specific testing done for complex changes_

### Screenshots
_Add screenshots for visual/layout changes_

### Breaking changes
_List any breaking changes or migration notes_

</details>

