### PR TITLE
Doc/build cache nano pico warning

### DIFF
--- a/content/doc/administrate/apps-management.md
+++ b/content/doc/administrate/apps-management.md
@@ -30,6 +30,8 @@ Stop functionality is useful during the development of the application to limit 
 
 {{< callout type="info" >}}
   If you set [`CC_DISABLE_BUILD_CACHE_UPLOAD`](/doc/develop/env-variables/#settings-you-can-define-using-environment-variables) environment variable to `true`, the cache archive won't be created nor uploaded.
+
+  Nano and Pico plans always use a dedicated build, which requires the build cache. Setting this environment variable on these plans causes deployment to fail.
 {{< /callout >}}
 
 ## Deploy an old commit

--- a/content/doc/administrate/apps-management.md
+++ b/content/doc/administrate/apps-management.md
@@ -28,9 +28,8 @@ Stop functionality is useful during the development of the application to limit 
 
 ![Manage your application from the Console](/images/app-management.png)
 
-{{< callout type="info" >}}
-  If you set [`CC_DISABLE_BUILD_CACHE_UPLOAD`](/doc/develop/env-variables/#settings-you-can-define-using-environment-variables) environment variable to `true`, the cache archive won't be created nor uploaded.
-{{< /callout >}}
+> [!NOTE]
+> If you set [`CC_DISABLE_BUILD_CACHE_UPLOAD`](/doc/develop/env-variables/#settings-you-can-define-using-environment-variables) environment variable to `true`, the cache archive won't be created nor uploaded. Don't use it with `nano` and `pico` plans which always use a build instance to create the build cache.
 
 ## Deploy an old commit
 

--- a/content/doc/develop/build-hooks.md
+++ b/content/doc/develop/build-hooks.md
@@ -99,6 +99,8 @@ This hook is perfect for:
 
 {{< callout type="info" >}}
   If you set [\`CC_DISABLE_BUILD_CACHE_UPLOAD\`](/doc/develop/env-variables/#settings-you-can-define-using-environment-variables) environment variable to `true`, the cache archive won't be created nor uploaded.
+
+  Nano and Pico plans always use a dedicated build, which requires the build cache. Setting this environment variable on these plans causes deployment to fail.
 {{< /callout >}}
 
 ### Pre Run

--- a/content/doc/develop/build-hooks.md
+++ b/content/doc/develop/build-hooks.md
@@ -97,9 +97,8 @@ This hook is perfect for:
 
 - extra build steps that you want to cache (eg bundling your frontend assets)
 
-{{< callout type="info" >}}
-  If you set [\`CC_DISABLE_BUILD_CACHE_UPLOAD\`](/doc/develop/env-variables/#settings-you-can-define-using-environment-variables) environment variable to `true`, the cache archive won't be created nor uploaded.
-{{< /callout >}}
+> [!NOTE]
+> If you set [`CC_DISABLE_BUILD_CACHE_UPLOAD`](/doc/develop/env-variables/#settings-you-can-define-using-environment-variables) environment variable to `true`, the cache archive won't be created nor uploaded. Don't use it with `nano` and `pico` plans which always use a build instance to create the build cache.
 
 ### Pre Run
 


### PR DESCRIPTION
## 📝 What does this PR do?

Adds a notice in the **CC_DISABLE_BUILD_CACHE_UPLOAD** callouts to warn that Nano and Pico plans always use a dedicated build, which requires the build cache. Setting this environment variable on these plans causes deployment to fail.

The notice has been added in two places:
- doc/develop/build-hooks.md (Post Build hook section)
- doc/administrate/apps-management.md (Start/Stop/Restart section)



## 🔗 Related Issue (if applicable)

- Closes #
- Related to #

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers

---

<details>
<summary>📋 <strong>For major changes</strong> (click to expand)</summary>

### Additional testing performed
_Describe any specific testing done for complex changes_

### Screenshots
_Add screenshots for visual/layout changes_

### Breaking changes
_List any breaking changes or migration notes_

</details>

