### PR TITLE
doc: add custom base configuration section to database add-ons

### DIFF
--- a/content/doc/addons/elastic.md
+++ b/content/doc/addons/elastic.md
@@ -201,3 +201,7 @@ If you think your system might require some customization (like some plugins act
 ## Migrations and upgrades
 
 When migrating or upgrading an Elasticsearch instance — especially when it's deployed as a cluster with multiple VMs and nodes — contact [our support team](https://console.clever-cloud.com/ticket-center-choice) beforehand to confirm feasibility and coordinate the operation without disruption.
+
+## Custom base configuration
+
+{{% content "db-custom-config" %}}

--- a/content/doc/addons/elastic.md
+++ b/content/doc/addons/elastic.md
@@ -187,16 +187,16 @@ It's important here to set `number_of_replicas` to zero to avoid triggering clus
 
 ## 🔑 Rights and permissions
 
-Elastic Stack add-ons are **managed services**, with Clever Cloud in charge of configuring and maintaining native configuration files. Some operations like adding an oauth source to connect to Kibana can't be added, as well as some native settings modifications. This ensures optimal performances and security for managed services as configured by Clever Cloud.
+Elastic Stack add-ons are **managed services**. Clever Cloud configures and maintains their native configuration files. You can change most settings from Kibana or by API, but some native settings, such as adding an OAuth source to Kibana, aren't available directly. This ensures optimal performance and security.
 
-Most settings are available for modifications and update from Kibana or by API, for example:
+Settings you can change include:
 
-- Managing users permissions
-- Frequencies of back-ups
-- The lifecycle of backups indexes
-- Backups destination
+- Manage user permissions
+- Set backup frequency
+- Manage the lifecycle of backup indexes
+- Configure the backup destination
 
-If you think your system might require some customization (like some plugins activation), contact Clever Cloud support to explain your use case and we will work with you to find a solution.
+If your use case requires changing a native configuration file or another unavailable setting, contact [Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to discuss feasibility.
 
 ## Migrations and upgrades
 

--- a/content/doc/addons/mongodb.md
+++ b/content/doc/addons/mongodb.md
@@ -99,3 +99,7 @@ Here is the list of actions that you won't be able to perform:
 - Backup frequency or retention control.
 
 Ask Clever Cloud support if you want to perform one of these actions.
+
+## Custom base configuration
+
+{{% content "db-custom-config" %}}

--- a/content/doc/addons/mongodb.md
+++ b/content/doc/addons/mongodb.md
@@ -82,20 +82,20 @@ Note that these features are available for all our databases add-ons, in additio
 
 ## 🔑 Rights and permissions
 
-Add-ons are managed services, meaning that users have **standard access** to the database (role **owner**). Some operations like databases and users creation, as well as some settings modifications aren't available by default. This ensures optimal performances and security for managed services as configured by Clever Cloud.
+Clever Cloud configures and maintains the MongoDB server. You have **standard access** to the database through the **owner** role, but some administrative operations and server settings aren't available directly. This ensures optimal performance and security.
 
 Authorized actions:
+
 - Manage collections (create, delete…).
 - Manage indexes.
 - Manage documents.
 
-If you think your system might require more advanced administrative access, [contact Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to explain your use case, and we will work with you to find a solution.
+The following actions aren't available directly:
 
-Here is the list of actions that you won't be able to perform:
 - Database administration (for example you won't be able to create new databases).
-- Users administration (you won't be able to create other users than the one handled with our control plane, ie the base owner and read-only users).
+- Users administration (you won't be able to create other users than the one handled with our control plane, i.e. the base owner and read-only users).
 - Server configuration update.
 - Cluster creation.
 - Backup frequency or retention control.
 
-Ask Clever Cloud support if you want to perform one of these actions.
+If your use case requires specific server parameters or one of these restricted operations, contact [Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to discuss feasibility.

--- a/content/doc/addons/mysql.md
+++ b/content/doc/addons/mysql.md
@@ -88,3 +88,7 @@ Here is the list of actions that you won't be able to perform:
 - Create Trigger or Function (Only on DEV plan)
 
 Ask Clever Cloud support if you want to perform one of these actions.
+
+## Custom base configuration
+
+{{% content "db-custom-config" %}}

--- a/content/doc/addons/mysql.md
+++ b/content/doc/addons/mysql.md
@@ -70,21 +70,21 @@ As Shared databases (DEV) are shared between multiple applications and delays co
 
 ## 🔑 Rights and permissions
 
-Add-ons are managed services, meaning that users have **standard access** to the database (**ALL privileges**). Some operations like databases and users creation, as well as some settings modifications aren't available by default. This ensures optimal performances and security for managed services as configured by Clever Cloud.
+Clever Cloud configures and maintains the MySQL server. You have **standard access** to the database with **ALL privileges**, but some administrative operations and server settings aren't available directly. This ensures optimal performance and security.
 
 Authorized actions:
+
 - Manage tables (create, delete…).
 - Manage indexes.
 
-If you think your system might require more advanced administrative access, contact [Clever Cloud Support](https://console.clever-cloud.com/ticket-center-choice) to explain your use case, and we will work with you to find a solution.
+The following actions aren't available directly:
 
-Here is the list of actions that you won't be able to perform:
 - Database administration (for example you won't be able to create new databases).
 - Users administration (you won't be able to create other users than the one handled with our control plane, i.e. the base owner and read-only users).
 - Server configuration update.
 - Plugins installation.
 - Replica creation.
 - Backup frequency or retention control.
-- Create Trigger or Function (Only on DEV plan)
+- Create triggers or functions (DEV plans only).
 
-Ask Clever Cloud support if you want to perform one of these actions.
+If your use case requires specific server parameters or one of these restricted operations, contact [Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to discuss feasibility.

--- a/content/doc/addons/postgresql.md
+++ b/content/doc/addons/postgresql.md
@@ -184,3 +184,7 @@ Here is the list of actions that you won't be able to perform:
 - Back-up frequency or retention control.
 
 Ask Clever Cloud support if you want to perform one of these actions.
+
+## Custom base configuration
+
+{{% content "db-custom-config" %}}

--- a/content/doc/addons/postgresql.md
+++ b/content/doc/addons/postgresql.md
@@ -170,23 +170,23 @@ If you want to use [pg_activity](https://github.com/dalibo/pg_activity) on a Pos
 
 ## 🔑 Rights and permissions
 
-Add-ons are managed services, meaning that users have **standard access** to the database (role **owner**). Some operations like databases and users creation, as well as some settings modifications aren't available by default. This ensures optimal performances and security for managed services as configured by Clever Cloud.
+Clever Cloud configures and maintains the PostgreSQL server. You have **standard access** to the database through the **owner** role, but some administrative operations and server settings aren't available directly. This ensures optimal performance and security.
 
 Authorized actions:
+
 - Manage tables (create, delete…).
 - Manage schemas.
 - Manage indexes.
 - Access information from **pg_catalog** (except **pg_database** on DEV plan).
 - Access to basic maintenance operations such as *VACUUM* and *ANALYZE*.
 
-If you think your system might require more advanced administrative access, [contact Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to explain your use case, and we will work with you to find a solution.
+The following actions aren't available directly:
 
-Here is the list of actions that you won't be able to perform:
 - Database administration (for example you won't be able to create new databases).
 - Users administration (you won't be able to create other users than the one handled with our control plane, i.e. the base owner and read-only users).
 - Server configuration update.
 - Extensions installation.
 - Replica creation.
-- Back-up frequency or retention control.
+- Backup frequency or retention control.
 
-Ask Clever Cloud support if you want to perform one of these actions.
+If your use case requires specific server parameters or one of these restricted operations, contact [Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to discuss feasibility.

--- a/content/doc/addons/redis.md
+++ b/content/doc/addons/redis.md
@@ -74,3 +74,7 @@ Here is the list of actions that you won't be able to perform:
 - Backup frequency or retention control.
 
 Ask Clever Cloud support if you want to perform one of these actions.
+
+## Custom base configuration
+
+{{% content "db-custom-config" %}}

--- a/content/doc/addons/redis.md
+++ b/content/doc/addons/redis.md
@@ -59,18 +59,18 @@ please contact the support to change its policy.
 
 ## 🔑 Rights and permissions
 
-Add-ons are managed services, meaning that users have **controlled access** to the server. They are granted access to all proposed operations except changing the server configuration. Based on the plan, they are granted access to a fix amount of databases. This ensures optimal performances and security for managed services as configured by Clever Cloud.
+Clever Cloud configures and maintains the Redis server. You have **controlled access** to its operations, except those that change the server configuration. Your plan determines the number of databases you can access. This ensures optimal performance and security.
 
 Authorized actions:
+
 - Access to one or more databases depending on your plan.
 - Access to all Redis operations except *CONFIG* and *CLUSTER*.
-- Set up replica via clever cloud console.
+- Set up a replica from the Clever Cloud Console.
 
-If you think your system might require more advanced administrative access, [contact Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to explain your use case, and we will work with you to find a solution.
+The following actions aren't available directly:
 
-Here is the list of actions that you won't be able to perform:
 - Server configuration update.
 - Modules installation.
 - Backup frequency or retention control.
 
-Ask Clever Cloud support if you want to perform one of these actions.
+If your use case requires specific server parameters or one of these restricted operations, contact [Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to discuss feasibility.

--- a/shared/db-custom-config.md
+++ b/shared/db-custom-config.md
@@ -1,0 +1,1 @@
+By default, the server is configured by Clever Cloud to ensure optimal performance and security. If your use case requires specific server parameters, contact [Clever Cloud support](https://console.clever-cloud.com/ticket-center-choice) to discuss feasibility.


### PR DESCRIPTION
## 📝 What does this PR do?

Adds a dedicated Custom base configuration section to the five managed database add-on pages (PostgreSQL, MySQL, MongoDB, Redis, Elastic). This section informs users that the server is configured by Clever Cloud, and that any custom server parameters require contacting support to discuss feasibility.

The paragraph is stored in a single shared file (shared/db-custom-config.md) and included via shortcode in each add-on page, so a future update only requires editing one file.




## 🔗 Related Issue (if applicable)

- Closes #
- Related to #

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers

