### PR TITLE
addons(postgresql): List pg_partman as extension that can be installed

### DIFF
--- a/content/doc/addons/postgresql.md
+++ b/content/doc/addons/postgresql.md
@@ -146,6 +146,7 @@ Extension   | Description
 pg_cron     | Job scheduler for PostgreSQL
 pg_ivm      | Incremental view maintenance for PostgreSQL
 pg_net      | Enables asynchronous (non-blocking) HTTP/HTTPS requests with SQL
+pg_partman  | Extension to manage partitioned tables by time or ID
 pg_repack   | Reorganize tables in PostgreSQL databases with minimal locks
 pgaudit     | Provides detailed session and/or object audit logging via the standard PostgreSQL logging facility
 pgsql-http  | HTTP client for PostgreSQL


### PR DESCRIPTION
## 📝 What does this PR do?

Add pg_partman in the list of extension that can be installed


## 🔗 Related Issue (if applicable)

- Closes #
- Related to #

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers

---

<details>
<summary>📋 <strong>For major changes</strong> (click to expand)</summary>

### Additional testing performed
_Describe any specific testing done for complex changes_

### Screenshots
_Add screenshots for visual/layout changes_

### Breaking changes
_List any breaking changes or migration notes_

</details>

