### PR TITLE
fix(log-management): update access logs formats to clever-tools v4

### DIFF
--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -57,15 +57,7 @@ clever logs --addon <addon_xxx>
 
 ### Access logs
 
-It contains all incoming requests to your application. Here is an example:
-
-```txt
-255.255.255.255 - - [06/Feb/2020:07:59:22 +0100] "GET /aget/to/your/beautiful/website -" 200 1453
-```
-
-They are available in different formats, the most common is CLF which stands for Common Log Format.
-
-You can see access logs with the following command:
+It contains all incoming HTTP requests to your application. You can see access logs with the following command:
 
 ```bash
 clever accesslogs
@@ -74,48 +66,67 @@ clever accesslogs
 As with the `logs` command, you can specify `--before` and `--after` flags.
 If you don't specify any options, the logs display continuously.
 
-To change the output, specify the `--format` flag with one of these values:
+To change the output, specify the `--format` (`-F`) flag with one of these values:
 
-- simple: `2021-06-25T10:11:35.358Z 255.255.255.255 GET /`
-- extended: `2021-06-25T10:11:35.358Z [ 255.255.255.255 - Nantes, FR ] GET www.clever.cloud / 200`
-- clf: `255.255.255.255 - - [25/Jun/2021:12:11:35 +0200] "GET / -" 200 562`
-- json:
+- `human` (default): a human-readable, colored table
+
+  ```txt
+  2026-06-24T08:05:43.880Z   255.255.255.255   FR/Nantes   200   GET  /
+  ```
+
+- `clf`: [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format)
+
+  ```txt
+  255.255.255.255 - - [24/Jun/2026:08:05:43 +0000] "GET /" 200 562
+  ```
+
+  The HTTP protocol version isn't part of the access log payload, so the request line is limited to `method path` (no `HTTP/x.y` token).
+
+- `json`: a JSON array of log objects (requires a bounding flag such as `--before`)
+- `json-stream`: one JSON log object per line
+
+  Both JSON formats share the same object shape:
 
   ```json
-    {
-        "t":"2021-06-25T10:11:35.358209Z",
-        "a":"app_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "adc":"clevercloud-adc-nX",
-        "o":"orga_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "i":"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        "ipS":"255.255.255.255",
-        "pS":58477,
-        "s":{
-            "lt":50.624,
-            "lg":3.0511,
-            "ct":"Nantes",
-            "co":"FR"
-        },
-        "ipD":"46.252.181.17",
-        "pD":14001,
-        "d":{
-            "lt":45.7059,
-            "lg":4.7444,
-            "ct":"Chaponost",
-            "co":"FR"
-        },
-        "vb":"GET",
-        "path":"/",
-        "bIn":658,"bOut":562,
-        "h":"www.clever.cloud",
-        "rTime":"31ms",
-        "sTime":"75μs",
-        "scheme":"HTTPS",
-        "sC":200,"sT":"OK",
-        "w":"WRK-01",
-        "r":"01F91AEG8Z9RJKYB7JY7H56FNB",
-        "tlsV":"TLS1.3"
-    }
+  {
+    "id": "01F91AEG8Z9RJKYB7JY7H56FNB",
+    "date": "2026-06-24T08:05:43.880Z",
+    "applicationId": "app_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "instanceId": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "region": "par",
+    "zone": "par",
+    "requestId": "01F91AEG8Z9RJKYB7JY7H56FNB",
+    "bytesIn": 658,
+    "bytesOut": 562,
+    "source": {
+      "ip": "255.255.255.255",
+      "port": 58477,
+      "city": "Nantes",
+      "countryCode": "FR",
+      "geoLocation": { "latitude": 50.624, "longitude": 3.0511 }
+    },
+    "destination": {
+      "ip": "46.252.181.17",
+      "port": 14001,
+      "city": "Chaponost",
+      "countryCode": "FR",
+      "geoLocation": { "latitude": 45.7059, "longitude": 4.7444 }
+    },
+    "http": {
+      "request": {
+        "method": "GET",
+        "path": "/",
+        "host": "www.clever-cloud.com",
+        "scheme": "https"
+      },
+      "response": {
+        "statusCode": 200,
+        "serviceTime": null,
+        "time": 31
+      }
+    },
+    "tls": null
+  }
   ```
 
 ## Exporting logs to an external tool

--- a/content/doc/administrate/log-management.md
+++ b/content/doc/administrate/log-management.md
@@ -83,7 +83,7 @@ To change the output, specify the `--format` (`-F`) flag with one of these value
   The HTTP protocol version isn't part of the access log payload, so the request line is limited to `method path` (no `HTTP/x.y` token).
 
 - `json`: a JSON array of log objects (requires a bounding flag such as `--before`)
-- `json-stream`: one JSON log object per line
+- `json-stream`: a stream of JSON log objects
 
   Both JSON formats share the same object shape:
 

--- a/content/doc/reference/cli.md
+++ b/content/doc/reference/cli.md
@@ -279,7 +279,7 @@ clever accesslogs [options]
 -a, --alias <alias>               Short name for the application
     --app <app-id|app-name>       Application to manage by its ID (or name, if unambiguous)
     --before, --until <before>    Fetch logs before this date/time (ISO8601 date, positive number in seconds or duration, e.g.: 1h)
--F, --format <format>             Output format (human, json, json-stream) (default: human)
+-F, --format <format>             Output format (human, json, json-stream, clf) (default: human)
 ```
 
 ## activity
@@ -1075,6 +1075,30 @@ clever drain [options]
 -F, --format <format>          Output format (human, json) (default: human)
 ```
 
+### drain check
+
+**Description:** Check that a drain's recipient is reachable and accepts deliveries
+
+**Since:** 4.11.0
+
+**Usage**
+```
+clever drain check <drain-id> [options]
+```
+
+**Arguments**
+```
+drain-id                       Drain ID
+```
+
+**Options**
+```
+    --addon <addon-id>         Add-on ID or real ID
+-a, --alias <alias>            Short name for the application
+    --app <app-id|app-name>    Application to manage by its ID (or name, if unambiguous)
+-F, --format <format>          Output format (human, json) (default: human)
+```
+
 ### drain create
 
 **Description:** Create a drain
@@ -1088,7 +1112,7 @@ clever drain create <drain-type> <drain-url> [options]
 
 **Arguments**
 ```
-drain-type                           Drain type (datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)
+drain-type                           Drain type (betterstack, datadog, elasticsearch, newrelic, ovh-tcp, raw-http, syslog-tcp, syslog-udp)
 drain-url                            Drain URL
 ```
 
@@ -1101,6 +1125,7 @@ drain-url                            Drain URL
 -i, --index-prefix <index-prefix>    Optional index prefix (for elasticsearch), `logstash` value is used if not set
 -p, --password <password>            Basic auth password (for elasticsearch or raw-http)
 -s, --sd-params <sd-params>          RFC5424 structured data parameters (for ovh-tcp), e.g.: `X-OVH-TOKEN=\"REDACTED\"`
+-t, --source-token <source-token>    Source token (for betterstack)
 -u, --username <username>            Basic auth username (for elasticsearch or raw-http)
 ```
 


### PR DESCRIPTION
## Context

Reported in [clever-tools#909](https://github.com/CleverCloud/clever-tools/issues/909): the **Access logs** section of `log-management.md` is out of date. It still describes the Warp10-era `clever accesslogs`:

- formats `simple` and `extended` no longer exist (the CLI now uses `human`, `json`, `json-stream`, and `clf`)
- the CLF example shows a stray `-` for the missing HTTP protocol (`"GET / -"`)
- the JSON sample uses the old short-key payload (`ipS`, `vb`, `bOut`…) instead of the v4 access log shape

## Proposal

Rewrite the section to match the current CLI output:

- `human` (default), `clf`, `json`, `json-stream`
- CLF request line reduced to `method path` — the protocol version is absent from the v4 payload, and a `-` placeholder breaks structured parsing in grok/GoAccess (see clever-tools PR #1104)
- JSON example updated to the real v4 `ApplicationAccessLog` object

Paired with clever-tools PR [#1104](https://github.com/CleverCloud/clever-tools/pull/1104), which restores the `clf` format in the CLI.