### PR TITLE
changelog: images updates, 2026W27

### DIFF
--- a/content/changelog/2026/07-01-images-update.md
+++ b/content/changelog/2026/07-01-images-update.md
@@ -1,0 +1,34 @@
+---
+title: "Images update: Gradle 9.6, Hugo 0.163, Docker 29.6"
+description: A tools bump release, Hugo 0.163 is now the default for static applications
+date: 2026-07-01
+tags:
+  - images
+  - update
+authors:
+  - name: David Legrand
+    link: https://github.com/davlgd
+    image: https://github.com/davlgd.png?size=40
+excludeSearch: true
+---
+
+We updated all our images. Deployment is in progress for all our users.
+
+* **Common:**
+  * cURL 8.21.0
+  * Mise 2026.6.14
+  * NGINX 1.30.3
+* **Docker:**
+  * Update to 29.6.1
+* **Java:**
+  * Gradle 9.6.1
+* **PHP:**
+  * `mod_ssl` module is now loaded
+* **Python:**
+  * uv 0.11.25
+* **Static:**
+  * Hugo 0.163.3
+
+## Hugo version update
+
+Starting with this release, we only support Hugo 0.160 and newer. If you are using an older version, update your application or [use Mise](/doc/reference/reference-environment-variables#install-tools-with-mise-package-manager) to download it during deployment. If you don't set `CC_HUGO_VERSION`, `0.163` is now the default.

--- a/content/doc/applications/static.md
+++ b/content/doc/applications/static.md
@@ -110,7 +110,7 @@ Supported Static Site Generators (SSG) are:
 - Detected file: `hugo.toml`, `hugo.yaml`, `hugo.json`
 
 > [!TIP] Set the Hugo version
->Use a specific Hugo version by setting the `CC_HUGO_VERSION` environment variable to `0.147`, `0.148`, `0.149` (default), `0.150`, `0.151`, `0.152`, `0.159`, `0.160`, `0.161` or `0.162`.
+>Use a specific Hugo version by setting the `CC_HUGO_VERSION` environment variable to `0.160`, `0.161` , `0.162` or `0.163` (default).
 
 ### mdBook
 


### PR DESCRIPTION
## 📝 What does this PR do?

This PR adds an entry about images updates, 2026W27

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [x] 📅 Changelog update
- [ ] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors
