### PR TITLE
Fix immutable infrastructure link

### DIFF
--- a/content/doc/administrate/ssh-clever-tools.md
+++ b/content/doc/administrate/ssh-clever-tools.md
@@ -19,7 +19,7 @@ aliases:
 
 Clever Cloud allows you to connect to running instances via SSH.
 
-While direct SSH access to instances is not recommended in an [immutable infrastructure](https://boxfuse.com/blog/no-ssh.html) setup, it can be useful for debugging purposes.
+While direct SSH access to instances is not recommended in an [immutable infrastructure](https://glossary.cncf.io/immutable-infrastructure/) setup, it can be useful for debugging purposes.
 
 ## Purpose
 


### PR DESCRIPTION
## 📝 What does this PR do?

Replaces the retired Boxfuse article link with the corresponding CloudCaptain page about immutable infrastructure. Boxfuse now redirects to the CloudCaptain home page, which loses the linked context.

## 🔗 Related Issue (if applicable)

- Closes #983

---

## 🧪 Type of Change

- [x] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers
