### PR TITLE
java: default version is 21 since December 2023, not 11

### DIFF
--- a/content/doc/find-help/faq.md
+++ b/content/doc/find-help/faq.md
@@ -139,7 +139,7 @@ As an example, if a Spring Boot application was compiled with Java `17` and run 
 java.lang.UnsupportedClassVersionError: org/springframework/boot/loader/JarLauncher has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
 ```
 
-By default, Java apps on Clever Cloud use Java `11`, but you can change it. Please head [over here](/doc/applications/java/java-jar/#available-java-versions "Java versions") for more information.
+By default, Java apps on Clever Cloud use Java `21`, but you can change it. Please head [over here](/doc/applications/java/java-jar/#available-java-versions "Java versions") for more information.
 
 For reference, the table below lists the class file version for each major Java version ([official doc](https://docs.oracle.com/javase/specs/jvms/se21/html/jvms-4.html)) :
 

--- a/data/runtime_versions.yml
+++ b/data/runtime_versions.yml
@@ -41,7 +41,7 @@ frankenphp:
 java:
   eol_source: https://adoptium.net/fr/support/
   default:
-    - 11
+    - 21
   accepted:
     - 25
     - 24 (EOL)


### PR DESCRIPTION
## Summary

The changelog announced on 2023-12-18 that **Java 21 is now the default version** for new applications ("Java 21 now used by default"). However:

- `data/runtime_versions.yml` still declares `default: 11`, which feeds the versions table rendered on every Java page (Jar, Maven, Gradle, War) via the `runtimes_versions` shortcode
- the FAQ answer about `UnsupportedClassVersionError` still says "By default, Java apps on Clever Cloud use Java 11"

Practical impact: a user compiling with Java 17/21 reads in the official docs that their app will run on Java 11 and crash with `UnsupportedClassVersionError` - the docs steer them toward a problem that no longer exists.

## Changes

- `data/runtime_versions.yml`: java default 11 -> 21
- FAQ: update the default version mentioned in the UnsupportedClassVersionError answer

## Note for reviewers

21 matches the December 2023 changelog. If the platform default has moved again since (25 is in the accepted list), happy to adjust to whatever the current default actually is - the point is that 11 is wrong either way.

## Test plan

- [ ] Confirm Java pages render default 21 from `runtime_versions.yml`
- [ ] Confirm FAQ UnsupportedClassVersionError answer mentions Java 21
