### PR TITLE
docs: remove metrics beta notice

### DIFF
--- a/content/doc/metrics/_index.md
+++ b/content/doc/metrics/_index.md
@@ -19,10 +19,6 @@ aliases:
 - /doc/tools/metrics
 - /metrics
 ---
-{{< callout type="warning" >}}
-Clever Cloud Metrics is still in beta.
-{{< /callout >}}
-
 In addition to logs, you can have access to metrics to know how your application behaves.
 By default, system metrics like CPU and RAM use are available, as well as application-level metrics when available (apache or nginx status for instance).
 


### PR DESCRIPTION
## Summary

Remove the outdated beta notice from the Metrics documentation.

## Rationale

The beta banner has already been removed from the console, and production application programming interfaces have been built to support it. The documentation can therefore reflect the current product status.