### PR TITLE
develop(request-flow): Document OAuth2 Proxy configuration

### DIFF
--- a/.github/styles/config/vocabularies/Doc/accept.txt
+++ b/.github/styles/config/vocabularies/Doc/accept.txt
@@ -32,6 +32,7 @@ DNS
 Dockerfile
 downtimes
 eg
+Entra
 EOL
 ESLint
 failover
@@ -45,6 +46,7 @@ Glassfish
 Gradle
 gradle
 Grafana
+hardcoded
 healthcheck
 Heptapod
 Hextra
@@ -65,6 +67,7 @@ Materia
 Matomo
 maven
 Metabase
+middleware
 monolog
 monorepo
 monorepository
@@ -76,6 +79,7 @@ nmap
 npm
 Nuxt
 OAuth
+Okta
 Otoroshi
 packageManager
 Payara

--- a/content/doc/applications/python/uv.md
+++ b/content/doc/applications/python/uv.md
@@ -40,22 +40,23 @@ The uv cache (`~/.cache/uv`) is included in the build cache to speed up subseque
 
 ## Run phase
 
-The application starts with the command defined in `CC_PYTHON_UV_RUN_COMMAND`. It must start an HTTP server listening on `0.0.0.0:8080`.
+The application starts with the command defined in `CC_PYTHON_UV_RUN_COMMAND`. It must start an HTTP server listening on `0.0.0.0:$PORT`. Clever Cloud sets `PORT` to `8080` by default. Set it to `9000` when you enable at least one [Request Flow middleware](/doc/develop/request-flow/#port-management).
 
 `CC_RUN_COMMAND` takes precedence over `CC_PYTHON_UV_RUN_COMMAND` if both are set.
 
 | Name | Description | Required | Default |
-|------|-------------|----------|---------|
+| ---- | ----------- | -------- | ------- |
 | `CC_PYTHON_UV_RUN_COMMAND` | Command to start the application (e.g. `uv run python app.py`) | Yes | - |
 | `CC_RUN_COMMAND` | Overrides `CC_PYTHON_UV_RUN_COMMAND` if set | No | - |
 | `ENVIRONMENT` | Set to `development` to include dev dependencies during build | No | `production` |
+| `PORT` | Port used by your HTTP server | No | `8080` |
 
 ## Differences with legacy Python deployment
 
 With native uv deployment:
 
 - No Nginx, uWSGI, or Gunicorn is involved
-- Your application listens on port `8080` (not `9000`)
+- Your application manages its HTTP server and listens on the port defined by `PORT`
 - `CC_PYTHON_MODULE` and `CC_PYTHON_BACKEND` are ignored
 - [Redirection.io, Varnish and custom proxies](/doc/develop/request-flow/) are configured through Request Flow, not Nginx
 - [Server configuration](/doc/applications/python/servers/) settings do not apply

--- a/content/doc/develop/_index.md
+++ b/content/doc/develop/_index.md
@@ -16,13 +16,14 @@ aliases:
 ---
 
 {{< cards >}}
+  {{< card link="/developers/doc/develop/tasks" title="Clever Tasks" icon="play-circle" >}}
+  {{< card link="/developers/doc/develop/healthcheck" title="Deployment healthcheck path" icon="check" >}}
   {{< card link="/developers/doc/develop/build-hooks" title="Deployment hooks" icon="rocket-launch" >}}
   {{< card link="/developers/doc/reference/reference-environment-variables" title="Environment variables reference" icon="creds" >}}
   {{< card link="/developers/doc/develop/env-variables" title="How environment variables work" icon="question-mark-circle" >}}
-  {{< card link="/developers/doc/develop/workers" title="Workers" icon="arrow-path" >}}
-  {{< card link="/developers/doc/develop/tasks" title="Clever Tasks" icon="play-circle" >}}
-  {{< card link="/developers/doc/develop/healthcheck" title="Deployment healthcheck path" icon="check" >}}
+  {{< card link="/developers/doc/develop/network-groups" title="Network Groups" icon="tcp-ip-service" >}}
+  {{< card link="/developers/doc/develop/oauth2-proxy" title="OAuth2 Proxy" icon="lock-closed" >}}
   {{< card link="/developers/doc/develop/request-flow" title="Request Flow" icon="traffic-light" >}}
   {{< card link="/developers/doc/develop/varnish" title="Varnish as HTTP cache" icon="arrow-trending-up" >}}
-  {{< card link="/developers/doc/develop/network-groups" title="Network Groups" icon="tcp-ip-service" >}}
+  {{< card link="/developers/doc/develop/workers" title="Workers" icon="arrow-path" >}}
 {{< /cards >}}

--- a/content/doc/develop/oauth2-proxy.md
+++ b/content/doc/develop/oauth2-proxy.md
@@ -1,0 +1,156 @@
+---
+type: docs
+linkTitle: OAuth2 Proxy
+title: OAuth2 Proxy
+description: Add OAuth2 Proxy authentication to applications through Request Flow on Clever Cloud without changing application code
+keywords:
+- oauth2-proxy
+- authentication
+- oidc
+- sso
+- request flow
+- reverse proxy
+---
+
+## Overview
+
+[Request Flow](/doc/develop/request-flow/) puts authentication in front of any application through [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/), with no change to your code: a few environment variables are enough. Clever Cloud starts the middleware, allocates its port, points it at your application, and keeps it in the chain alongside Varnish, Redirection.io or a proxy of your own with the same flexibility. It's available on every runtime that supports Request Flow.
+
+OAuth2 Proxy redirects unauthenticated visitors to the identity provider you configure, and only authenticated requests reach your application. This suits a staging environment, an internal dashboard or an administration interface.
+
+Clever Cloud sets the port OAuth2 Proxy listens on and the address of your application. Every other setting comes from `OAUTH2_PROXY_*` environment variables, which map one to one to the [OAuth2 Proxy configuration options](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview).
+
+## Enable OAuth2 Proxy
+
+Add `oauth2-proxy` to the `CC_REQUEST_FLOW` environment variable:
+
+```bash
+CC_REQUEST_FLOW="oauth2-proxy"
+```
+
+Request Flow allows you to use OAuth2 Proxy with other middleware such as [Varnish](/doc/develop/varnish/) or [Redirection.io](https://redirection.io/) for example. List every middleware in the order you want, from the public port to your application:
+
+```bash
+CC_REQUEST_FLOW="oauth2-proxy,varnish"
+```
+
+## Minimal configuration
+
+OAuth2 Proxy validates its configuration at startup and exits when a required setting is missing, which fails your deployment. The following variables are the smallest working set for a GitHub identity provider, and the same structure applies to every provider. Replace every value with your own:
+
+```bash
+CC_REQUEST_FLOW="oauth2-proxy"
+OAUTH2_PROXY_PROVIDER="github"
+OAUTH2_PROXY_CLIENT_ID="<your-client-id>"
+OAUTH2_PROXY_CLIENT_SECRET="<your-client-secret>"
+OAUTH2_PROXY_COOKIE_SECRET="<your-cookie-secret>"
+OAUTH2_PROXY_EMAIL_DOMAINS="example.com"
+OAUTH2_PROXY_REDIRECT_URL="https://app.example.com/oauth2/callback"
+```
+
+The redirect URL must point to the public domain of your application, followed by `/oauth2/callback`. Declare that exact URL in your identity provider as an authorised callback, otherwise the provider rejects the login with a `redirect_uri mismatch` error.
+
+For an OpenID Connect provider such as Okta or Microsoft Entra ID, set the provider to `oidc` and give the issuer URL. The `email` scope feeds the address that authorization rules check, so request it explicitly:
+
+```bash
+OAUTH2_PROXY_PROVIDER="oidc"
+OAUTH2_PROXY_OIDC_ISSUER_URL="https://sso.example.com"
+OAUTH2_PROXY_SCOPE="openid email profile"
+```
+
+Keycloak has a provider of its own, `keycloak-oidc`, pointing at the realm you want:
+
+```bash
+OAUTH2_PROXY_PROVIDER="keycloak-oidc"
+OAUTH2_PROXY_OIDC_ISSUER_URL="https://sso.example.com/realms/internal"
+OAUTH2_PROXY_SCOPE="openid email profile"
+```
+
+> [!NOTE]
+> The [OAuth2 Proxy client installation provider](https://github.com/please-openit/keycloak-oauth2proxy-client-installation-provider) writes these variables for you from your Keycloak client settings. Install the extension in the `providers` folder of your [Keycloak add-on](/doc/addons/keycloak/#custom-themes-and-plugins), then download "Oauth2-proxy environment variables" from the Installation tab of your client. [This video](https://www.youtube.com/watch?v=Jo-Njxsxq-8) presents it, in French.
+
+## Generate the cookie secret
+
+OAuth2 Proxy encrypts session cookies with an AES cipher and accepts a secret of 16, 24, or 32 bytes only. A hexadecimal string generated with `openssl rand -hex 32` counts as 64 bytes and gets rejected at startup. Generate a valid secret with:
+
+```bash
+openssl rand -base64 32 | tr '+/' '-_'
+```
+
+Use a different secret for each application. Changing the secret invalidates every existing session and signs all users out.
+
+## Authorize users
+
+Authenticating a visitor and authorizing them are two different steps. Once the identity provider confirms who the visitor is, OAuth2 Proxy compares the email address it received against your authorization rules, and answers `403 Forbidden` when no rule matches, even though the login succeeded.
+
+One of these rules is mandatory at startup, which prevents an accidentally open proxy. Set `OAUTH2_PROXY_EMAIL_DOMAINS` to a comma-separated list of domains, prefixing a domain with a dot to include its subdomains, or set `OAUTH2_PROXY_AUTHENTICATED_EMAILS_FILE` to the path of a file listing one authorized address per line:
+
+```bash
+OAUTH2_PROXY_EMAIL_DOMAINS="example.com,.corp.example.com"
+```
+
+The value `*` authorizes any address the provider validates, which means you rely entirely on the provider for identity checks. With an identity provider restricted to your organisation, this is the expected setting. With a public provider such as GitHub or Google, it accepts every account of that provider, so pick the scope you want: a domain list, an authenticated emails file, or a provider-level rule such as `OAUTH2_PROXY_GITHUB_ORG`.
+
+## Pass the identity to your application
+
+OAuth2 Proxy forwards the visitor identity to your application by default through `X-Forwarded-User`, `X-Forwarded-Groups`, `X-Forwarded-Email` and `X-Forwarded-Preferred-Username` headers.
+
+To also forward the OpenID Connect ID token in the `Authorization` header, enable:
+
+```bash
+OAUTH2_PROXY_PASS_AUTHORIZATION_HEADER="true"
+```
+
+This suits an application that validates the token itself. Only trust these identity headers on requests that have passed through OAuth2 Proxy.
+
+## Listen on the right port
+
+When your application manages its own HTTP server, it must listen on port `9000` while Request Flow is active. Clever Cloud handles the backend configuration for runtimes with a managed web server or port. In every other runtime, set the port yourself:
+
+```bash
+PORT="9000"
+```
+
+> [!NOTE]
+> This works as long as your application listens on `0.0.0.0:$PORT` rather than on a hardcoded port. Read the [Request Flow port management](/doc/develop/request-flow/#port-management) section for the details of the whole chain.
+
+## Keep the health check working
+
+The platform health check requests your application through the public port, which OAuth2 Proxy now answers. A redirect to the login page still counts as a healthy answer, so the default health check keeps working.
+
+This changes as soon as you configure [`CC_HEALTH_CHECK_PATH`](/doc/develop/healthcheck/), which expects a `2xx` status. An authenticated path never returns one to the health check, so exclude it from authentication:
+
+```bash
+CC_HEALTH_CHECK_PATH="/health"
+OAUTH2_PROXY_SKIP_AUTH_ROUTES="^/health$"
+```
+
+This exclusion makes the health check path publicly accessible. Limit its response to the application's health status and don't expose sensitive data.
+
+## Scale to several instances
+
+OAuth2 Proxy stores sessions in the cookie by default, so every instance of your application validates them without shared state. Horizontal scaling and instance replacement need no extra configuration.
+
+Tokens with many claims, particularly Microsoft Entra ID tokens carrying group memberships, can make sessions exceed the 4 kB limit for a single cookie. OAuth2 Proxy splits large sessions across several cookies, but the resulting headers can still exceed browser or proxy limits. In that case, store sessions in a [Redis add-on](/doc/addons/redis/) and copy its connection URL into the variable:
+
+```bash
+OAUTH2_PROXY_SESSION_STORE_TYPE="redis"
+OAUTH2_PROXY_REDIS_CONNECTION_URL="redis://:password@host:port"
+```
+
+## Troubleshooting
+
+OAuth2 Proxy logs its configuration errors and exits, so read the deployment logs from the bottom up. The health check reports the public port as closed, which is a consequence of the middleware being down rather than a problem with your application:
+
+| Log message | Cause |
+| ----------- | ----- |
+| `cookie_secret must be 16, 24, or 32 bytes` | The secret has the wrong length, see [Generate the cookie secret](#generate-the-cookie-secret) |
+| `missing setting for email validation` | The configuration carries neither `OAUTH2_PROXY_EMAIL_DOMAINS` nor `OAUTH2_PROXY_AUTHENTICATED_EMAILS_FILE` |
+| `Your application is not listening on 8080` | OAuth2 Proxy failed to start, the preceding message holds the reason |
+| `Some software are not listening as expected: 9000` | OAuth2 Proxy runs, your application doesn't listen on port `9000` |
+
+A login that loops between your application and the identity provider points to `OAUTH2_PROXY_REDIRECT_URL` not matching the callback declared in the provider. A `403 Forbidden` after a successful login points to an email address outside your authorization rules, or to a missing `email` scope.
+
+- [Learn more about Request Flow](/doc/develop/request-flow/)
+- [Learn more about OAuth2 Proxy configuration](https://oauth2-proxy.github.io/oauth2-proxy/)
+- [Configure your health check](/doc/develop/healthcheck/)

--- a/content/doc/develop/request-flow.md
+++ b/content/doc/develop/request-flow.md
@@ -23,10 +23,10 @@ Request Flow is Clever Cloud's automatic middleware chaining mechanism. It confi
 ## Supported services
 
 | Service | Activation | Description |
-|---------|-----------|-------------|
+| ------- | ---------- | ----------- |
 | `block` | `CC_REQUEST_FLOW="block"` | Blocks public access with a `200 OK` response. Other ports remain accessible through [Network Groups](/doc/develop/network-groups/) |
-| `custom` | `CC_REQUEST_FLOW_CUSTOM` | Any custom reverse proxy |
-| `oauth2-proxy` | `CC_REQUEST_FLOW="oauth2-proxy"` | Authentication proxy using [OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/) |
+| `custom` | `CC_REQUEST_FLOW="custom"` | Any custom reverse proxy, started with `CC_REQUEST_FLOW_CUSTOM` |
+| `oauth2-proxy` | `CC_REQUEST_FLOW="oauth2-proxy"` | Authentication proxy using [OAuth2 Proxy](/doc/develop/oauth2-proxy/) |
 | `otoroshi-challenge` | `OTOROSHI_CHALLENGE_SECRET` | [Otoroshi](/doc/addons/otoroshi/) challenge verification proxy |
 | `redirectionio` | `CC_REDIRECTIONIO_PROJECT_KEY` | HTTP redirects, rewrites, SEO |
 | `varnish` | `clevercloud/varnish.vcl` file or `CC_VARNISH_FILE` | HTTP cache accelerator |
@@ -39,20 +39,26 @@ When no `CC_REQUEST_FLOW` is set, Clever Cloud detects and activates services au
 - If a `clevercloud/varnish.vcl` file exists (or `CC_VARNISH_FILE` is set), Varnish is activated
 - If `CC_REDIRECTIONIO_PROJECT_KEY` is set, Redirection.io is activated
 
-All three can be active simultaneously. Default order: Otoroshi Challenge first, then Varnish, then Redirection.io.
+When automatically detected, Otoroshi Challenge, Varnish and Redirection.io can run simultaneously, in this order: Otoroshi Challenge, Varnish, then Redirection.io.
+
+No automatic detection exists for `oauth2-proxy` and `custom`. Only `CC_REQUEST_FLOW` activates them. Setting this variable also replaces automatic detection for the whole chain, so a `CC_REQUEST_FLOW="oauth2-proxy"` on an application holding a `clevercloud/varnish.vcl` file starts OAuth2 Proxy alone. List every middleware you need: `CC_REQUEST_FLOW="oauth2-proxy,varnish"`.
 
 ## Port management
 
-Request Flow allocates ports in a chain from port `8080` (public) down to the application:
+Request Flow allocates middleware ports in a chain from port `8080` (public) down to your application. For runtimes where you configure the application HTTP server yourself:
 
 - With no middleware: your application listens directly on port `8080`
 - With one middleware: the middleware listens on `8080`, forwards to your application on port `9000`
-- With two middleware: first listens on `8080`, forwards to second on `8081`, which forwards to the application on `9000`
-
-Your application must listen on port `8080` when no middleware is active, or on port `9000` when at least one middleware is configured.
+- With two middleware services: the first listens on `8080`, forwards to the second on `8081`, which forwards to the application on `9000`
 
 > [!NOTE]
-> In runtimes where Clever Cloud manages the port configuration (FrankenPHP, Java, PHP, Static), port allocation is handled transparently with no additional configuration.
+> FrankenPHP, Java, PHP, legacy Python, Ruby and Static applications need no additional configuration, as Clever Cloud manages their web server or port transparently. Python applications using native uv support manage their own HTTP server and follow the port rule above.
+
+In every runtime where your application manages its own HTTP server, have it listen on `0.0.0.0:$PORT` and set `PORT` to `9000` when a middleware is active:
+
+```bash
+PORT="9000"
+```
 
 ## Explicit configuration with CC_REQUEST_FLOW
 
@@ -62,7 +68,7 @@ To control the order or selection of middleware, set `CC_REQUEST_FLOW` to a comm
 CC_REQUEST_FLOW="redirectionio,varnish"
 ```
 
-This inverts the default order: Redirection.io listens on `8080`, forwards to Varnish on `8081`, which forwards to the application on `9000`.
+For an application that manages its own HTTP server, this inverts the default order: Redirection.io listens on `8080`, forwards to Varnish on `8081`, which forwards to the application on `9000`.
 
 ### Disable Request Flow
 
@@ -84,12 +90,7 @@ CC_REQUEST_FLOW="block"
 
 ### Health check with block mode
 
-By default, `block` responds `200 OK` regardless of your application's actual state. If [`CC_HEALTH_CHECK_PATH` or `CC_HEALTH_CHECK_PATH_0` to `CC_HEALTH_CHECK_PATH_5`](/doc/develop/healthcheck/) are configured, the blocking service also checks these paths on your application and responds accordingly:
-
-- `200 OK` if all configured paths return a `2xx` status
-- `503 Service Unavailable` if the application is down or any path returns a non-`2xx` status
-
-This way, the platform's health check still reflects the actual state of your application even when public traffic is blocked.
+With `block` enabled, the deployment health check only verifies that the blocking service listens on port `8080` and responds `200 OK`. It doesn't send an HTTP request to your application, including when you configure [`CC_HEALTH_CHECK_PATH` or `CC_HEALTH_CHECK_PATH_0` to `CC_HEALTH_CHECK_PATH_5`](/doc/develop/healthcheck/).
 
 ## Custom middleware
 
@@ -100,7 +101,8 @@ CC_REQUEST_FLOW="redirectionio,custom,varnish"
 CC_REQUEST_FLOW_CUSTOM="./my-proxy --listen @@LISTEN_PORT@@ --forward @@FORWARD_PORT@@"
 ```
 
-In this example:
+For an application that manages its own HTTP server, this example produces the following chain:
+
 - Redirection.io listens on `8080`, forwards to custom middleware on `8081`
 - Custom middleware listens on `8081`, forwards to Varnish on `8082`
 - Varnish listens on `8082`, forwards to the application on `9000`
@@ -108,15 +110,21 @@ In this example:
 ## Environment variables reference
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | `CC_REQUEST_FLOW` | Comma-separated list of middleware to chain (e.g. `varnish,redirectionio`). Special values: `disable`, `block` |
 | `CC_REQUEST_FLOW_CUSTOM` | Command to start a custom middleware. Must contain `@@LISTEN_PORT@@` and `@@FORWARD_PORT@@` placeholders |
 | `CC_REDIRECTIONIO_PROJECT_KEY` | Redirection.io project key. Activates Redirection.io in the request flow |
 | `CC_VARNISH_FILE` | Path to a custom Varnish VCL file (default: `clevercloud/varnish.vcl`) |
 | `OTOROSHI_CHALLENGE_SECRET` | Otoroshi challenge secret. Activates Otoroshi Challenge verification in the request flow |
 
+## Troubleshooting
+
+A middleware that fails to start leaves the public port closed, and the deployment ends with `Your application is not listening on 8080`. This message names the public port of the chain, which belongs to the first middleware rather than to your application. Read the preceding deployment logs: the middleware logs its own error before exiting.
+
+The message `Some software are not listening as expected: 9000` means the opposite. Every middleware runs, and your application doesn't listen on the port the chain forwards to. Check the [port management](#port-management) section for the port your runtime expects.
+
 - [Learn more about Varnish on Clever Cloud](/doc/develop/varnish/)
 - [Learn more about Redirection.io](https://redirection.io/)
-- [Learn more about OAuth2 Proxy](https://oauth2-proxy.github.io/oauth2-proxy/)
+- [Learn more about OAuth2 Proxy on Clever Cloud](/doc/develop/oauth2-proxy/)
 - [Learn more about Otoroshi on Clever Cloud](/doc/addons/otoroshi/)
 - [Learn more about Network Groups](/doc/develop/network-groups/)

--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -111,6 +111,8 @@ Use these to define [commands to run](/doc/develop/build-hooks) between various 
 |[`CC_METRICS_PROMETHEUS_PORT`](/doc/metrics/#publish-your-own-metrics "Publish your own metrics") | Define the port on which the Prometheus endpoint is available | 9100 |
 |[`CC_METRICS_PROMETHEUS_RESPONSE_TIMEOUT`](/doc/metrics/#publish-your-own-metrics "Publish your own metrics") | Define the timeout in seconds to collect the application metrics. This value **must** be below 60 seconds as data are collected every minutes | 3 |
 |[`CC_METRICS_PROMETHEUS_USER`](/doc/metrics/#publish-your-own-metrics "Publish your own metrics") | Define the user for the basic auth of the Prometheus endpoint | |
+|[`CC_REQUEST_FLOW`](/doc/develop/request-flow "Request Flow") | Comma-separated list of middleware to chain between the public port and your application (`block`, `custom`, `oauth2-proxy`, `otoroshi-challenge`, `redirectionio`, `varnish`). Special values: `disable`, `block` | |
+|[`CC_REQUEST_FLOW_CUSTOM`](/doc/develop/request-flow/#custom-middleware "Request Flow") | Command starting a custom middleware, with the `@@LISTEN_PORT@@` and `@@FORWARD_PORT@@` placeholders | |
 |[`CC_VARNISH_FILE`](/doc/develop/varnish "Cache") | The path to the Varnish configuration file, relative to your application root | `/clevercloud/varnish.vcl` |
 |[`CC_VARNISH_STORAGE_SIZE`](/doc/develop/varnish "Cache") | Configure the size of the Varnish cache. | 1G |
 |[`CC_WORKER_COMMAND`](/doc/develop/workers "Workers") | Command to run in background as a worker process. You can run multiple workers. |  |

--- a/shared/request-flow.md
+++ b/shared/request-flow.md
@@ -1,15 +1,17 @@
-## Request Flow: Varnish, Redirection.io, custom proxy
+## Request Flow: Varnish, Redirection.io, OAuth2 Proxy, custom proxy
 
-Request Flow automatically chains reverse proxies between port `8080` (public) and your application, managing port allocation with no manual configuration. Supported services are activated by their presence in your project:
+Request Flow automatically chains reverse proxies between port `8080` (public) and your application, allocating middleware ports automatically. Some services are detected from your configuration, while others must be listed explicitly in `CC_REQUEST_FLOW`:
 
 - **Otoroshi Challenge**: set `OTOROSHI_CHALLENGE_SECRET`
 - **Varnish**: add a `clevercloud/varnish.vcl` file or set `CC_VARNISH_FILE`
 - **Redirection.io**: set `CC_REDIRECTIONIO_PROJECT_KEY`
+- **OAuth2 Proxy**: set `CC_REQUEST_FLOW=oauth2-proxy` and its `OAUTH2_PROXY_*` settings
 
-All three can be active simultaneously. To control the order, set `CC_REQUEST_FLOW` (e.g. `redirectionio,varnish`). To add a custom middleware, include `custom` in the chain and define `CC_REQUEST_FLOW_CUSTOM` with `@@LISTEN_PORT@@` and `@@FORWARD_PORT@@` placeholders. To block public access, set `CC_REQUEST_FLOW=block`.
+Multiple services can run simultaneously. Setting `CC_REQUEST_FLOW` replaces automatic detection, so list every service you need in order (e.g. `oauth2-proxy,varnish`). To add a custom middleware, include `custom` in the chain and define `CC_REQUEST_FLOW_CUSTOM` with `@@LISTEN_PORT@@` and `@@FORWARD_PORT@@` placeholders. To block public access, set `CC_REQUEST_FLOW=block`.
 
-When at least one middleware is active, your application must listen on port `9000` instead of `8080`.
+If your application manages its own HTTP server, configure it to listen on port `9000` instead of `8080` when at least one middleware is active. Clever Cloud handles this automatically for runtimes with a managed web server.
 
 - [Learn more about Request Flow](/doc/develop/request-flow/)
 - [Learn more about Varnish on Clever Cloud](/doc/develop/varnish/)
+- [Learn more about OAuth2 Proxy on Clever Cloud](/doc/develop/oauth2-proxy/)
 - [Learn more about Redirection.io](https://redirection.io/)


### PR DESCRIPTION
## 📝 What does this PR do?

OAuth2 Proxy is supported by Request Flow, but the documentation only listed it in the services table with a link to the upstream site. None of the settings it needs to start were documented, so an application enabling `CC_REQUEST_FLOW="oauth2-proxy"` fails to deploy with `invalid configuration: cookie_secret must be 16, 24, or 32 bytes` and `missing setting for email validation`, then reports the misleading `Your application is not listening on 8080`.

This PR adds a dedicated OAuth2 Proxy page and fixes the surrounding Request Flow content:

- **New page `/doc/develop/oauth2-proxy/`**: minimal working configuration for GitHub and OIDC providers, cookie secret generation (`openssl rand -hex 32` produces 64 bytes and is rejected), email authorisation and the authentication/authorisation distinction, `OAUTH2_PROXY_REVERSE_PROXY` behind the Clever Cloud reverse proxy, port `9000`, keeping the health check working with `CC_HEALTH_CHECK_PATH`, identity forwarding, sessions and horizontal scaling, settings managed by the platform, and a troubleshooting table mapping log messages to causes.
- **Request Flow page**: setting `CC_REQUEST_FLOW` replaces automatic detection for the whole chain, which was not stated. The list of runtimes managing the port was missing Python and Ruby. Added a troubleshooting section explaining that `not listening on 8080` names the public port of the chain, held by the first middleware, not by the application.
- **Environment variable reference**: `CC_REQUEST_FLOW` and `CC_REQUEST_FLOW_CUSTOM` were absent. `PORT` was described as "The mandatory port value is 8080", which stopped being true when Request Flow shipped.
- **`shared/request-flow.md`**: OAuth2 Proxy added to the block included by every runtime page.

## 🔗 Related Issue (if applicable)

- Closes #
- Related to #

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [x] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [ ] The site builds without errors

Hugo was not available locally, so the build check is left to CI.

---

## 👥 Reviewers

@CleverCloud/reviewers

---

<details>
<summary>📋 <strong>Follow-up, out of scope for this PR</strong> (click to expand)</summary>

- No `oauth2-proxy` entry exists in `data/runtime_versions.yml`, so the page cannot display the shipped version the way the Varnish page does.
- OAuth2 Proxy was never announced in a changelog. The three Request Flow entries only cover Varnish, Redirection.io and `custom`.
- The 2026-02-25 changelog states Request Flow is available "in all our runtimes". The Docker and Jenkins deploy types do not set up a request flow, so this needs confirmation.

</details>