### PR TITLE
develop: List the missing pages on the section index

### DIFF
--- a/content/doc/develop/_index.md
+++ b/content/doc/develop/_index.md
@@ -20,5 +20,9 @@ aliases:
   {{< card link="/developers/doc/reference/reference-environment-variables" title="Environment variables reference" icon="creds" >}}
   {{< card link="/developers/doc/develop/env-variables" title="How environment variables work" icon="question-mark-circle" >}}
   {{< card link="/developers/doc/develop/workers" title="Workers" icon="arrow-path" >}}
+  {{< card link="/developers/doc/develop/tasks" title="Clever Tasks" icon="play-circle" >}}
   {{< card link="/developers/doc/develop/healthcheck" title="Deployment healthcheck path" icon="check" >}}
+  {{< card link="/developers/doc/develop/request-flow" title="Request Flow" icon="traffic-light" >}}
+  {{< card link="/developers/doc/develop/varnish" title="Varnish as HTTP cache" icon="arrow-trending-up" >}}
+  {{< card link="/developers/doc/develop/network-groups" title="Network Groups" icon="tcp-ip-service" >}}
 {{< /cards >}}


### PR DESCRIPTION
## 📝 What does this PR do?

The `/doc/develop/` index shows five cards while the section holds nine pages. Clever Tasks, Request Flow, Varnish and Network Groups are only reachable through the sidebar or the search, although Request Flow and Varnish are linked from most runtime pages.

This PR adds the four missing cards, keeping the existing order and picking icons from `data/icons.yaml`.

A fifth page, OAuth2 Proxy, is added by #994. Its card will come with a rebase once that PR is merged, to keep this one free of dependencies.

## 🔗 Related Issue (if applicable)

- Closes #
- Related to #994

---

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [x] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [ ] The site builds without errors

Hugo was not available locally, so the build check is left to CI.

---

## 👥 Reviewers

@CleverCloud/reviewers