### PR TITLE
fix: add missing value in node build tools

### DIFF
--- a/content/doc/reference/reference-environment-variables.md
+++ b/content/doc/reference/reference-environment-variables.md
@@ -262,7 +262,7 @@ Use Linux runtime with [Mise package manager](#install-tools-with-mise-package-m
 |[`CC_NODE_VERSION`](/doc/applications/nodejs#set-nodejs-version)| Set Node.js version, for example `24`, `23.11` or `22.15.1` | |
 |`CC_NODE_DEV_DEPENDENCIES` | Control if development dependencies are installed or not. Values are either `install` or `ignore` | `ignore` |
 |`CC_RUN_COMMAND` | Define a custom command. Example for Meteor: `node .build/bundle/main.js <options>`  | |
-|`CC_NODE_BUILD_TOOL` | Choose your build tool between npm, npm-ci, yarn, yarn2 and custom | npm |
+|`CC_NODE_BUILD_TOOL` | Choose your build tool between bun, npm, npm-ci, pnpm, yarn, yarn2, yarn-berry and custom | npm |
 |`CC_CUSTOM_BUILD_TOOL`| A custom command to run (with `CC_NODE_BUILD_TOOL` set to `custom`) | |
 |`CC_NPM_REGISTRY` | The host of your private repository, available values: `github` or the registry host. | registry.npmjs.org |
 |`CC_NPM_BASIC_AUTH`| Private repository credentials, in the form `user:password`. You can't use this if `CC_NPM_TOKEN` is set | |

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -87,9 +87,8 @@ Depending on your package manager, use the following environment variables:
   {{< /tab >}}
   {{< tab name="pnpm" icon="pnpm" >}}
     ```shell
-    CC_NODE_BUILD_TOOL="custom"
-    CC_PRE_BUILD_HOOK="npm install -g pnpm && pnpm install"
-    CC_CUSTOM_BUILD_TOOL="pnpm run astro telemetry disable && pnpm build"
+    CC_NODE_BUILD_TOOL="pnpm"
+    CC_POST_BUILD_HOOK="pnpm run astro telemetry disable && pnpm build"
     CC_RUN_COMMAND="pnpm run preview"
     ```
   {{< /tab >}}


### PR DESCRIPTION
## 📝 What does this PR do?

This pr simply add a missing value in the node build tool env.
I hope it can help the confusion that can be created by saying in the documentation
that we support pnpm but pnpm not being present.
Someone that i helped using clever had this confusion.

## 🧪 Type of Change

- [ ] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [X] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors

---

## 👥 Reviewers

@CleverCloud/reviewers