### PR TITLE
develop(request-flow): document Docker limitation

### DIFF
--- a/content/doc/develop/request-flow.md
+++ b/content/doc/develop/request-flow.md
@@ -20,6 +20,8 @@ aliases:
 
 Request Flow is Clever Cloud's automatic middleware chaining mechanism. It configures reverse proxies and services between the public port (`8080`) and your application, managing port allocation automatically. There is no need to manually configure listening ports for each service.
 
+Request Flow is available for all runtimes except Docker, where you define and manage services within the container image.
+
 ## Supported services
 
 | Service | Activation | Description |


### PR DESCRIPTION
## 📝 What does this PR do?

Documents that Request Flow is available for every runtime except Docker, where services are defined and managed within the container image.

## 🔗 Related Issue

- Closes #977

---

## 🧪 Type of Change

- [x] 📚 Documentation update

---

## ✅ Quick Checklist

- [x] I have read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] The content is accurate and links work
- [x] The site builds without errors