### PR TITLE
Fix: CC_PRE_BUILD_HOOK is not run during deployments from cache

### DIFF
--- a/content/doc/develop/build-hooks.md
+++ b/content/doc/develop/build-hooks.md
@@ -74,10 +74,10 @@ If you need support for other hooks, please reach out to our support and explain
 
 **By using `CC_PRE_BUILD_HOOK`**.
 
-This hook is ran before the dependencies are fetched. If it fails, the
+This hook runs before the dependencies are fetched. If it fails, the
 deployment fails.
 
-This hook is not ran during deployments from cache.
+This hook doesn't run during deployments from cache.
 
 This hook is perfect for:
 
@@ -88,10 +88,10 @@ This hook is perfect for:
 
 **By using `CC_POST_BUILD_HOOK`.**
 
-This hook is ran after the project is built, and before the cache archive is
+This hook runs after the project is built, and before the cache archive is
 generated. If it fails, the deployment fails.
 
-This hook is not ran during deployments from cache.
+This hook doesn't run during deployments from cache.
 
 This hook is perfect for:
 
@@ -104,10 +104,10 @@ This hook is perfect for:
 
 **By using `CC_PRE_RUN_HOOK`.**
 
-This hook is ran before the application is started, but after the cache archive
+This hook runs before the application is started, but after the cache archive
 has been generated. If it fails, the deployment fails.
 
-This hook is ran every time.
+This hook runs every time.
 
 This hook is perfect for:
 
@@ -117,10 +117,10 @@ This hook is perfect for:
 
 **By using `CC_RUN_SUCCEEDED_HOOK` or `CC_RUN_FAILED_HOOK`.**
 
-These hooks are ran once the application has started (or has failed starting).
+These hooks run once the application has started (or has failed starting).
 Their failure doesn't cause the deployment to fail.
 
-One of these hooks is ran every time.
+One of these hooks runs every time.
 
 These hooks are perfect for:
 

--- a/content/doc/develop/build-hooks.md
+++ b/content/doc/develop/build-hooks.md
@@ -77,7 +77,7 @@ If you need support for other hooks, please reach out to our support and explain
 This hook is ran before the dependencies are fetched. If it fails, the
 deployment fails.
 
-This hook is ran every time.
+This hook is not ran during deployments from cache.
 
 This hook is perfect for:
 


### PR DESCRIPTION
## What

The **Pre Build** section states that `CC_PRE_BUILD_HOOK` "is ran every time". A deployment that reuses the build cache skips the whole build phase, so the Pre Build hook is not run either, exactly like the Post Build one.

This PR aligns the Pre Build wording with the Post Build wording. The Pre Run statement ("ran every time") matches what I observed and is left unchanged.

## How I checked

A PHP application with an `echo` in each of the four hooks, three deployments:

| Hook | New commit | `clever restart` | `clever restart --without-cache` |
|---|---|---|---|
| `CC_PRE_BUILD_HOOK` | ran | **not ran** | ran |
| `CC_POST_BUILD_HOOK` | ran | not ran | ran |
| `CC_PRE_RUN_HOOK` | ran | ran | ran |
| `CC_RUN_SUCCEEDED_HOOK` | ran | ran | ran |

Deployment logs for `clever restart`, which uses the build cache by default:

```
Checking cache data: GET /api/builds/app_.../<commit>/php-20260818
A build cache archive exists, downloading in progress…
Successfully downloaded build cache archive
Running CC_PRE_RUN_HOOK: echo ...
```

Nothing runs between the cache archive download and the Pre Run hook.

With `--without-cache`, the logs show `No build cache archive has been detected, performing a new build…`, followed by all four hooks in order.

Clever Tools 4.10, `php` runtime, `par` region.
