### PR TITLE
deploy(pulsar): fix set-offload-threshold typo

### DIFF
--- a/content/doc/deploy/pulsar/_index.md
+++ b/content/doc/deploy/pulsar/_index.md
@@ -114,5 +114,5 @@ The offload threshold of the namespace is deactivated by default, you can activa
 pulsarctl --admin-service-url $ADDON_PULSAR_HTTP_URL \
           --auth-params $ADDON_PULSAR_TOKEN \
           --auth-plugin org.apache.pulsar.client.impl.auth.AuthenticationToken \
-          namespaces set-offload-treshold $ADDON_PULSAR_TENANT/$ADDON_PULSAR_NAMESPACE 10G
+          namespaces set-offload-threshold $ADDON_PULSAR_TENANT/$ADDON_PULSAR_NAMESPACE 10G
 ```


### PR DESCRIPTION
## 📝 Summary

Fixes a typo in the Pulsar deployment documentation: `set-offload-treshold` is corrected to `set-offload-threshold` in the command example.

## 🔗 Related issue

- Closes #
- Related to #

## 🧪 Type of Change

- [x] ⚠️ Bug fix
- [ ] 📅 Changelog update
- [ ] 📚 Documentation update
- [ ] ✨ New content/feature
- [ ] 🔧 Technical/maintenance

## ✅ Validation

- [x] Read the [contributing guidelines](https://github.com/CleverCloud/documentation/blob/main/CONTRIBUTING.md)
- [x] Verify content accuracy and links
- [x] Run relevant checks and builds
- [x] Check the rendered result when the change affects layout or formatting
